### PR TITLE
 Handle user and group watches to group memberships

### DIFF
--- a/internal/controller/groupmembership_controller.go
+++ b/internal/controller/groupmembership_controller.go
@@ -264,7 +264,7 @@ func (r *GroupMembershipReconciler) enqueueGroupMembershipsForChange(ctx context
 	}
 
 	var groupMembershipList iammiloapiscomv1alpha1.GroupMembershipList
-	if err := r.List(ctx, &groupMembershipList); err != nil {
+	if err := r.List(ctx, &groupMembershipList, client.InNamespace("")); err != nil {
 		log.Error(err, "failed to list GroupMemberships")
 		return nil
 	}

--- a/internal/controller/groupmembership_controller.go
+++ b/internal/controller/groupmembership_controller.go
@@ -72,6 +72,11 @@ func (f *UserGroupFinalizer) Finalize(ctx context.Context, obj client.Object) (f
 		return finalizer.Result{}, err
 	}
 
+	if group.UID == "" || user.UID == "" {
+		log.Info("Group or user is not found, skipping finalization", "groupName", group.Name, "userName", user.Name)
+		return finalizer.Result{}, nil
+	}
+
 	log.Info("Removing group membership during finalization", "GroupMembership", groupMembership.Name, "groupRef", group.UID, "userRef", user.UID)
 
 	// Remove the group membership tuple from the OpenFGA store

--- a/test/iam/group-membership/chainsaw-test.yaml
+++ b/test/iam/group-membership/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  # This test is used to test the creation and deletion of a group membership
+  name: group-membership-creation-and-deletion
+spec:
+  steps:
+  - try:
+    - apply: # Create group
+        file: resources/group.yaml
+    - apply: # Create user
+        file: resources/user.yaml
+    - apply: # Create group membership
+        file: resources/group-membership.yaml
+    - wait: # Wait for group membership to be ready
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: test-user-membership
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - assert: # Assert that the group membership is created
+        file: resources/group-membership.yaml
+    - delete: # Delete group membership
+        file: resources/group-membership.yaml
+    - wait: # Wait for group membership to be deleted
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: test-user-membership
+        timeout: 5m
+        for:
+          deletion: {}
+    - error: # Assert that the group membership is deleted
+        file: resources/group-membership.yaml

--- a/test/iam/group-membership/chainsaw-test.yaml
+++ b/test/iam/group-membership/chainsaw-test.yaml
@@ -34,3 +34,5 @@ spec:
           deletion: {}
     - error: # Assert that the group membership is deleted
         file: resources/group-membership.yaml
+
+# TODO: Add tests for user and group changes, and then verify that the GroupMembership is updated, once the User and Group controllers are implemented

--- a/test/iam/group-membership/chainsaw-test.yaml
+++ b/test/iam/group-membership/chainsaw-test.yaml
@@ -66,12 +66,3 @@ spec:
             value: 'true'
     - assert: # Assert that the group membership is created
         file: resources/non-existent-refs-valid.yaml
-    - delete: # Delete group membership
-        file: resources/non-existent-group-membership.yaml
-    - wait: # Wait for group membership to be deleted
-        apiVersion: iam.miloapis.com/v1alpha1
-        kind: GroupMembership
-        name: non-existent-refs-membership
-        timeout: 5m
-        for:
-          deletion: {}

--- a/test/iam/group-membership/chainsaw-test.yaml
+++ b/test/iam/group-membership/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   name: group-membership-creation-and-deletion
 spec:
   steps:
+  # Test the creation and deletion of a group membership
   - try:
     - apply: # Create group
         file: resources/group.yaml
@@ -35,4 +36,33 @@ spec:
     - error: # Assert that the group membership is deleted
         file: resources/group-membership.yaml
 
-# TODO: Add tests for user and group changes, and then verify that the GroupMembership is updated, once the User and Group controllers are implemented
+  - try:
+    # Test the creation of a group membership with non-existent user and non-existent group
+    - apply: # Create group membership with non-existent user and non-existent group
+        file: resources/non-existent-group-membership.yaml
+    - wait: # Wait for group membership to be ready
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: non-existent-refs-membership
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'false'
+    - assert: # Assert that the group membership is not reconciled, it should be invalid because the user and group are not created
+        file: resources/non-existent-refs-invalid.yaml
+    - apply: # Create user
+        file: resources/non-existent-user.yaml
+    - apply: # Create group
+        file: resources/non-existent-group.yaml
+    - wait: # Wait for group membership to be ready, it should be ready now as the user and group are created and have watches
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: non-existent-refs-membership
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - assert: # Assert that the group membership is created
+        file: resources/non-existent-refs-valid.yaml

--- a/test/iam/group-membership/chainsaw-test.yaml
+++ b/test/iam/group-membership/chainsaw-test.yaml
@@ -66,3 +66,12 @@ spec:
             value: 'true'
     - assert: # Assert that the group membership is created
         file: resources/non-existent-refs-valid.yaml
+    - delete: # Delete group membership
+        file: resources/non-existent-group-membership.yaml
+    - wait: # Wait for group membership to be deleted
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: non-existent-refs-membership
+        timeout: 5m
+        for:
+          deletion: {}

--- a/test/iam/group-membership/resources/group-membership.yaml
+++ b/test/iam/group-membership/resources/group-membership.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: test-user-membership
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: test-user
+  groupRef:
+    name: test-group
+    namespace: ($namespace)

--- a/test/iam/group-membership/resources/group.yaml
+++ b/test/iam/group-membership/resources/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: test-group
+  namespace: ($namespace)

--- a/test/iam/group-membership/resources/non-existent-group-membership.yaml
+++ b/test/iam/group-membership/resources/non-existent-group-membership.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: non-existent-refs-membership
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: non-existent-user
+  groupRef:
+    name: non-existent-group
+    namespace: ($namespace)

--- a/test/iam/group-membership/resources/non-existent-group.yaml
+++ b/test/iam/group-membership/resources/non-existent-group.yaml
@@ -1,0 +1,5 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: non-existent-group
+  namespace: ($namespace)

--- a/test/iam/group-membership/resources/non-existent-refs-invalid.yaml
+++ b/test/iam/group-membership/resources/non-existent-refs-invalid.yaml
@@ -1,0 +1,16 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: non-existent-refs-membership
+  namespace: ($namespace)
+status:
+  conditions:
+    - type: UserRefValid
+      status: "False"
+      reason: ValidationFailed
+    - type: GroupRefValid
+      status: "False"
+      reason: ValidationFailed
+    - type: Ready
+      status: "False"
+      reason: ReferenceInvalid 

--- a/test/iam/group-membership/resources/non-existent-refs-valid.yaml
+++ b/test/iam/group-membership/resources/non-existent-refs-valid.yaml
@@ -1,0 +1,16 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: non-existent-refs-membership
+  namespace: ($namespace)
+status:
+  conditions:
+    - type: UserRefValid
+      status: "True"
+      reason: ValidationSuccessful
+    - type: GroupRefValid
+      status: "True"
+      reason: ValidationSuccessful
+    - type: Ready
+      status: "True"
+      reason: Reconciled 

--- a/test/iam/group-membership/resources/non-existent-user.yaml
+++ b/test/iam/group-membership/resources/non-existent-user.yaml
@@ -1,0 +1,6 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: non-existent-user 
+spec:
+  email: non-existent-user @datum.net

--- a/test/iam/group-membership/resources/user.yaml
+++ b/test/iam/group-membership/resources/user.yaml
@@ -1,0 +1,6 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: test-user
+spec:
+  email: test-user@datum.net

--- a/test/iam/policy-bindings/chainsaw-test.yaml
+++ b/test/iam/policy-bindings/chainsaw-test.yaml
@@ -225,6 +225,8 @@ spec:
           status:
             phase: Succeeded
 
+  
+  # Test that user can inherit the PolicyBinding of the group.
     - apply:
         file: group.yaml
         outputs:
@@ -349,6 +351,8 @@ spec:
             name: group-user-webhook-test
           status:
             phase: Succeeded
+
+  # Test that user lost the PolicyBinding of the group after the group membership is deleted.
     - delete: # Delete group membership
         file: group-memership.yaml
     - wait: # Wait for group membership to be deleted
@@ -398,11 +402,19 @@ spec:
                   )
                   echo "Webhook response: $response"
                   # Check if we got a valid SubjectAccessReview response
-                  if echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
-                    echo "Webhook test completed successfully"
+                  if ! echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                    echo "Webhook test failed - invalid response format"
+                    exit 1
+                  fi
+                  # Check if the request was allowed
+                  if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+                    echo "Webhook test completed successfully - access allowed"
                     exit 0
+                  elif echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*false'; then
+                    echo "Webhook test failed - access denied by authorization webhook"
+                    exit 1
                   else
-                    echo "Webhook test failed - invalid response"
+                    echo "Webhook test failed - could not determine allowed status"
                     exit 1
                   fi
               env:
@@ -411,7 +423,7 @@ spec:
                 - name: ORG_UID
                   value: ($org.metadata.uid)
     - sleep:
-        duration: 5s
+        duration: 30s
     - assert:
         resource:
           apiVersion: v1
@@ -419,7 +431,7 @@ spec:
           metadata:
             name: group-user-webhook-test-deletion
           status:
-            phase: Failed
+            phase: Failed # This should be failed because the group membership is deleted, and the user is not a member of the group anymore.
 
 
 

--- a/test/iam/policy-bindings/chainsaw-test.yaml
+++ b/test/iam/policy-bindings/chainsaw-test.yaml
@@ -349,3 +349,78 @@ spec:
             name: group-user-webhook-test
           status:
             phase: Succeeded
+    - delete: # Delete group membership
+        file: group-memership.yaml
+    - wait: # Wait for group membership to be deleted
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: example-groupmembership
+        timeout: 5m
+        for:
+          deletion: {}
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: group-user-webhook-test-deletion
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: curl
+              image: curlimages/curl:latest
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  response=$(curl -ksS https://auth-provider-openfga-openfga-authz-webhook-service.auth-provider-openfga-system.svc.cluster.local:9443/core/v1alpha/webhook \
+                    -H "Content-Type: application/json" \
+                    -d @- << EOF
+                  {
+                    "apiVersion": "authorization.k8s.io/v1",
+                    "kind": "SubjectAccessReview",
+                    "spec": {
+                      "user": "group-user-admin",
+                      "extra": {
+                        "resourcemanager.miloapis.com/organization-id": ["$(ORG_UID)"],
+                        "authentication.miloapis.com/user-uid": ["$(USER_UID)"]
+                      },
+                      "groups": ["system:authenticated"],
+                      "resourceAttributes": {
+                        "group": "resourcemanager.miloapis.com",
+                        "resource": "organizations",
+                        "version": "v1alpha1",
+                        "verb": "get",
+                        "name": "datum"
+                      }
+                    }
+                  }
+                  EOF
+                  )
+                  echo "Webhook response: $response"
+                  # Check if we got a valid SubjectAccessReview response
+                  if echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                    echo "Webhook test completed successfully"
+                    exit 0
+                  else
+                    echo "Webhook test failed - invalid response"
+                    exit 1
+                  fi
+              env:
+                - name: USER_UID
+                  value: ($grpUser.metadata.uid)
+                - name: ORG_UID
+                  value: ($org.metadata.uid)
+    - sleep:
+        duration: 5s
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: group-user-webhook-test-deletion
+          status:
+            phase: Failed
+
+
+
+    

--- a/test/iam/policy-bindings/chainsaw-test.yaml
+++ b/test/iam/policy-bindings/chainsaw-test.yaml
@@ -408,11 +408,11 @@ spec:
                   fi
                   # Check if the request was allowed
                   if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
-                    echo "Webhook test completed successfully - access allowed"
-                    exit 0
-                  elif echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*false'; then
-                    echo "Webhook test failed - access denied by authorization webhook"
+                    echo "Webhook test failed - access was allowed"
                     exit 1
+                  elif echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*false'; then
+                    echo "Webhook test succeeded - access denied by authorization webhook"
+                    exit 0
                   else
                     echo "Webhook test failed - could not determine allowed status"
                     exit 1
@@ -431,7 +431,7 @@ spec:
           metadata:
             name: group-user-webhook-test-deletion
           status:
-            phase: Failed # This should be failed because the group membership is deleted, and the user is not a member of the group anymore.
+            phase: Succeeded
 
 
 


### PR DESCRIPTION
- `GroupMembershipReconciler` now reconciles GroupMembership even if the `User` and `Group` resources have not been created yet.
 - This is achieved by adding watches for the secondary resources: `User` and `Group`.
- Introduced tests for group membership creation and deletion.
- Introduced end-to-end (e2e) tests that validate a user will lose access to a resource once the membership to the group with the relevant permissions has been removed.

> [!WARNING]
>
> Tests for automatic deletion of group memberships when a user or group is deleted will be added once their controllers and finalizers are implemented. This tests are going to be made on their respective PRs.

---

## Checklist

- [x] GroupMembershipReconciler handles user/group deletion and cleans up OpenFGA tuples.
- [x] Finalizer logic for GroupMembership is robust and idempotent.
- [x] Tests for group membership creation and deletion are included.