### PR TITLE
Fix end-to-end tests

### DIFF
--- a/config/authz-webhook/authz-webhook.yaml
+++ b/config/authz-webhook/authz-webhook.yaml
@@ -37,7 +37,7 @@ spec:
         - name: OPENFGA_API_URL
           value: openfga.openfga-system.svc.cluster.local:8081
         - name: OPENFGA_STORE_ID
-          value: r01JVTBDT6NJ541P1JBT22GX4PR
+          value: 01JVTBDT6NJ541P1JBT22GX4PR
         ports:
           - containerPort: 8080
             name: metrics

--- a/test/iam/policy-bindings/chainsaw-test.yaml
+++ b/test/iam/policy-bindings/chainsaw-test.yaml
@@ -194,11 +194,19 @@ spec:
                   )
                   echo "Webhook response: $response"
                   # Check if we got a valid SubjectAccessReview response
-                  if echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
-                    echo "Webhook test completed successfully"
+                  if ! echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                    echo "Webhook test failed - invalid response format"
+                    exit 1
+                  fi
+                  # Check if the request was allowed
+                  if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+                    echo "Webhook test completed successfully - access allowed"
                     exit 0
+                  elif echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*false'; then
+                    echo "Webhook test failed - access denied by authorization webhook"
+                    exit 1
                   else
-                    echo "Webhook test failed - invalid response"
+                    echo "Webhook test failed - could not determine allowed status"
                     exit 1
                   fi
               env:
@@ -311,11 +319,19 @@ spec:
                   )
                   echo "Webhook response: $response"
                   # Check if we got a valid SubjectAccessReview response
-                  if echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
-                    echo "Webhook test completed successfully"
+                  if ! echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                    echo "Webhook test failed - invalid response format"
+                    exit 1
+                  fi
+                  # Check if the request was allowed
+                  if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+                    echo "Webhook test completed successfully - access allowed"
                     exit 0
+                  elif echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*false'; then
+                    echo "Webhook test failed - access denied by authorization webhook"
+                    exit 1
                   else
-                    echo "Webhook test failed - invalid response"
+                    echo "Webhook test failed - could not determine allowed status"
                     exit 1
                   fi
               env:
@@ -333,7 +349,3 @@ spec:
             name: group-user-webhook-test
           status:
             phase: Succeeded
-
-
-
-    


### PR DESCRIPTION
Addresses an issue where the end-to-end tests weren't checking the `allowed` option returned in the response to determine if the user was actually provided access via the webhook. This ensures the tests will fail when the webhook response doesn't line up. 

We should eventually look at moving away from using a pod w/ a curl command and instead look at configuring the kind cluster with the authz webhook and use chainsaw to create SubjectAccessReviews directly. 

This also resolves an issue with the webhook configuration causing it to make invalid requests to OpenFGA. 