### PR TITLE
fix: check parent instance for specific-resource ops in scoped requests

### DIFF
--- a/internal/webhook/subjectaccessreview_authorizer.go
+++ b/internal/webhook/subjectaccessreview_authorizer.go
@@ -254,9 +254,21 @@ func (o *SubjectAccessReviewAuthorizer) Authorize(ctx context.Context, attribute
 	}
 	rootResource := o.buildRootResource(protectedResource)
 
-	// For scoped requests (project or organization), also check the scope-level
-	// root object. This covers ResourceKind PolicyBindings targeting all instances
-	// of the scope type (e.g. staff bindings on all Projects or all Organizations).
+	// For scoped requests (project, organization, or user-scoped via the
+	// /users/{id}/control-plane prefix), also check:
+	//
+	//   - the scope-level root object — catches ResourceKind PolicyBindings
+	//     targeting all instances of the scope type (e.g. staff bindings on
+	//     all Projects, all Organizations, or all Users).
+	//
+	//   - the parent INSTANCE — catches PolicyBindings bound to the specific
+	//     parent (e.g. the per-user `user-self-manage-{user}` PolicyBinding
+	//     bound to User:{userUID}). buildResourceObject only resolves to the
+	//     parent for collection ops; specific-resource ops (delete, get,
+	//     update on a named resource) resolve to the instance, which by
+	//     itself has no PolicyBinding. Without this extra check those ops
+	//     can't be authorised through a parent-scoped binding even when the
+	//     same role grants the verb at the parent level.
 	var extraChecks []*openfgav1.BatchCheckItem
 	if authCtx.parentContext != nil {
 		scopeRoot := fmt.Sprintf("iam.miloapis.com/Root:%s/%s", authCtx.parentContext.apiGroup, authCtx.parentContext.kind)
@@ -268,6 +280,19 @@ func (o *SubjectAccessReviewAuthorizer) Authorize(ctx context.Context, attribute
 			},
 			CorrelationId: "scope-root",
 		})
+		scopeParent := fmt.Sprintf("%s/%s:%s", authCtx.parentContext.apiGroup, authCtx.parentContext.kind, authCtx.parentContext.name)
+		// Avoid sending a duplicate when the primary check is already against
+		// the parent (collection ops resolve there via buildResourceObject).
+		if checkReq.TupleKey.Object != scopeParent {
+			extraChecks = append(extraChecks, &openfgav1.BatchCheckItem{
+				TupleKey: &openfgav1.CheckRequestTupleKey{
+					User:     checkReq.TupleKey.User,
+					Relation: checkReq.TupleKey.Relation,
+					Object:   scopeParent,
+				},
+				CorrelationId: "scope-parent",
+			})
+		}
 	}
 	decision, reason, checkErr = o.executeBatchCheck(ctx, checkReq, rootResource, extraChecks...)
 	authzStepDuration.WithLabelValues("openfga_batch_check").Observe(time.Since(stepStart).Seconds())

--- a/internal/webhook/subjectaccessreview_authorizer_test.go
+++ b/internal/webhook/subjectaccessreview_authorizer_test.go
@@ -979,6 +979,134 @@ func TestResourceKindBindingResolution(t *testing.T) {
 		assert.Equal(t, "iam.miloapis.com/Root:resourcemanager.miloapis.com/Project", checksById["scope-root"].TupleKey.Object)
 	})
 
+	t.Run("user-scoped specific-resource op includes scope-parent check for parent PolicyBindings", func(t *testing.T) {
+		// Reproduces the user-scoped sessions delete case: a request for
+		// `delete sessions/{name}` arrives via the user-scoped
+		// /apis/iam.miloapis.com/v1alpha1/users/{user}/control-plane prefix.
+		// The user has a PolicyBinding (e.g. `user-self-manage-{user}`)
+		// bound to their User resource, granting `sessions.delete`. The
+		// instance check (Session:{name}) and the resource Root
+		// (Root:identity.miloapis.com/Session) both deny because no
+		// PolicyBinding targets them. The scope-parent check
+		// (User:{userId}) is the only path that allows the request.
+		var capturedBatchReq *openfgav1.BatchCheckRequest
+		mockFGA := &mockFGAClient{
+			BatchCheckFunc: func(ctx context.Context, req *openfgav1.BatchCheckRequest, opts ...grpc.CallOption) (*openfgav1.BatchCheckResponse, error) {
+				capturedBatchReq = req
+				results := map[string]*openfgav1.BatchCheckSingleResult{}
+				for _, check := range req.Checks {
+					allowed := check.CorrelationId == "scope-parent"
+					results[check.CorrelationId] = &openfgav1.BatchCheckSingleResult{
+						CheckResult: &openfgav1.BatchCheckSingleResult_Allowed{Allowed: allowed},
+					}
+				}
+				return &openfgav1.BatchCheckResponse{Result: results}, nil
+			},
+		}
+
+		sessionResource := iamv1alpha1.ProtectedResource{
+			Spec: iamv1alpha1.ProtectedResourceSpec{
+				ServiceRef:  iamv1alpha1.ServiceReference{Name: "identity.miloapis.com"},
+				Plural:      "sessions",
+				Kind:        "Session",
+				Permissions: []string{"get", "list", "delete"},
+			},
+		}
+
+		auth := &webhook.SubjectAccessReviewAuthorizer{
+			FGAClient:              mockFGA,
+			ProtectedResourceCache: webhook.NewProtectedResourceCacheForTest([]iamv1alpha1.ProtectedResource{sessionResource}),
+			FGAStoreID:             "test_store",
+			DiscoveryClient:        &mockDiscoveryClient{},
+		}
+
+		attributes := &mockAttributes{
+			apiGroup: "identity.miloapis.com",
+			resource: "sessions",
+			name:     "session-abc",
+			verb:     "delete",
+			user: &user.DefaultInfo{
+				Name: "test-user",
+				UID:  "user-abc",
+				Extra: map[string][]string{
+					iamv1alpha1.ParentAPIGroupExtraKey: {"iam.miloapis.com"},
+					iamv1alpha1.ParentKindExtraKey:     {"User"},
+					iamv1alpha1.ParentNameExtraKey:     {"user-abc"},
+				},
+			},
+		}
+
+		decision, _, err := auth.Authorize(context.Background(), attributes)
+
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+		require.NotNil(t, capturedBatchReq, "BatchCheck should have been called")
+		require.Len(t, capturedBatchReq.Checks, 4, "BatchCheck must have instance, root, scope-root, and scope-parent checks")
+		checksById := make(map[string]*openfgav1.BatchCheckItem)
+		for _, c := range capturedBatchReq.Checks {
+			checksById[c.CorrelationId] = c
+		}
+		require.Contains(t, checksById, "instance")
+		require.Contains(t, checksById, "root")
+		require.Contains(t, checksById, "scope-root")
+		require.Contains(t, checksById, "scope-parent")
+		assert.Equal(t, "identity.miloapis.com/Session:session-abc", checksById["instance"].TupleKey.Object)
+		assert.Equal(t, "iam.miloapis.com/Root:identity.miloapis.com/Session", checksById["root"].TupleKey.Object)
+		assert.Equal(t, "iam.miloapis.com/Root:iam.miloapis.com/User", checksById["scope-root"].TupleKey.Object)
+		assert.Equal(t, "iam.miloapis.com/User:user-abc", checksById["scope-parent"].TupleKey.Object)
+	})
+
+	t.Run("project-scoped collection op does not duplicate scope-parent (primary check is already the parent)", func(t *testing.T) {
+		// For project-scoped collection ops the primary instance check is
+		// already against the Project; adding a scope-parent for the same
+		// object would be a duplicate. Confirm we still send only 3 checks
+		// (instance, root, scope-root) and skip scope-parent.
+		var capturedBatchReq *openfgav1.BatchCheckRequest
+		mockFGA := &mockFGAClient{
+			BatchCheckFunc: func(ctx context.Context, req *openfgav1.BatchCheckRequest, opts ...grpc.CallOption) (*openfgav1.BatchCheckResponse, error) {
+				capturedBatchReq = req
+				return &openfgav1.BatchCheckResponse{
+					Result: map[string]*openfgav1.BatchCheckSingleResult{
+						"instance":   {CheckResult: &openfgav1.BatchCheckSingleResult_Allowed{Allowed: true}},
+						"root":       {CheckResult: &openfgav1.BatchCheckSingleResult_Allowed{Allowed: false}},
+						"scope-root": {CheckResult: &openfgav1.BatchCheckSingleResult_Allowed{Allowed: false}},
+					},
+				}, nil
+			},
+		}
+
+		auth := &webhook.SubjectAccessReviewAuthorizer{
+			FGAClient:              mockFGA,
+			ProtectedResourceCache: webhook.NewProtectedResourceCacheForTest([]iamv1alpha1.ProtectedResource{computeWorkloadResource}),
+			FGAStoreID:             "test_store",
+			DiscoveryClient:        &mockDiscoveryClient{},
+		}
+
+		attributes := &mockAttributes{
+			apiGroup: "compute.miloapis.com",
+			resource: "workloads",
+			verb:     "list",
+			user: &user.DefaultInfo{
+				Name: "test-user",
+				UID:  "user-abc",
+				Extra: map[string][]string{
+					iamv1alpha1.ParentAPIGroupExtraKey: {"resourcemanager.miloapis.com"},
+					iamv1alpha1.ParentKindExtraKey:     {"Project"},
+					iamv1alpha1.ParentNameExtraKey:     {"proj-xyz"},
+				},
+			},
+		}
+
+		decision, _, err := auth.Authorize(context.Background(), attributes)
+
+		require.NoError(t, err)
+		assert.Equal(t, authorizer.DecisionAllow, decision)
+		require.Len(t, capturedBatchReq.Checks, 3, "scope-parent should be skipped when primary check is already the parent")
+		for _, c := range capturedBatchReq.Checks {
+			assert.NotEqual(t, "scope-parent", c.CorrelationId)
+		}
+	})
+
 	t.Run("BatchCheck allows when instance check allows (ResourceRef binding)", func(t *testing.T) {
 		// Instance check allows, Root denies — access must be granted.
 		mockFGA := &mockFGAClient{


### PR DESCRIPTION
## Summary
- Adds a `scope-parent` `BatchCheckItem` against the **parent instance** (`{parentApiGroup}/{parentKind}:{parentName}`) when the request carries a `parentContext`, alongside the existing `scope-root` check that targets the kind-level Root.
- Skips the new check when the primary instance check is already against the parent (collection ops in project/organization scope resolve there via `buildResourceObject`), so existing call shapes are unchanged.

## Why
Specific-resource operations arriving on a parent-scoped path were never authorised through PolicyBindings bound to the parent. `Authorize()` already constructs the parent-instance string in `buildParentResource`, but only uses it as the *primary* check object when `buildResourceObject` decides the request is a collection op — i.e. only for `list`/`watch`/`create`/no-name. For specific-resource verbs (`get`/`delete`/`update`/`patch` on a named resource) the primary check goes against the resource instance, and there's no PolicyBinding for that. The existing `scope-root` extra check only catches ResourceKind bindings (staff-style "applies to all instances of this kind") — it doesn't catch ResourceRef bindings on the parent.

Concrete failure mode that prompted this:

```
DELETE /apis/iam.miloapis.com/v1alpha1/users/{userId}/control-plane
       /apis/identity.miloapis.com/v1alpha1/sessions/{name}
→ 403  "User cannot delete resource sessions in API group identity.miloapis.com at the cluster scope"
```

Same path with `list` → 200. Same user, same Role (`iam-user-self-manage` includes both `sessions.list` and `sessions.delete`), same per-user `user-self-manage-{user}` PolicyBinding bound to `User:{userId}`. Asymmetry is entirely on the authorizer side: list resolves the OpenFGA object to the parent (`User:{userId}`) and matches the binding; delete resolves to `Session:{name}` and matches nothing.

## Fix shape
In `Authorize()`, when `parentContext != nil`:

```go
scopeRoot   := fmt.Sprintf("iam.miloapis.com/Root:%s/%s", parentAPIGroup, parentKind)
scopeParent := fmt.Sprintf("%s/%s:%s",                   parentAPIGroup, parentKind, parentName)

// scope-root catches ResourceKind bindings (existing).
extraChecks = append(extraChecks, &BatchCheckItem{Object: scopeRoot, CorrelationId: "scope-root"})

// scope-parent catches per-instance parent bindings (new). Dedup against
// the primary check, which already targets the parent for collection ops.
if checkReq.TupleKey.Object != scopeParent {
    extraChecks = append(extraChecks, &BatchCheckItem{Object: scopeParent, CorrelationId: "scope-parent"})
}
```

`BatchCheck` allows when *any* result allows, so the parent-instance binding becomes a viable allow path without weakening any existing decision.

## Test plan
- [x] Two new cases in `TestResourceKindBindingResolution`:
  - `user-scoped specific-resource op includes scope-parent check for parent PolicyBindings` — reproduces the regression: `delete sessions/{name}` is allowed because the User-bound PolicyBinding matches via `scope-parent`.
  - `project-scoped collection op does not duplicate scope-parent (primary check is already the parent)` — guards the dedup.
- [x] Existing project-scoped test (`project-scoped request uses BatchCheck against Project, Root, and scope-root`) still passes with `Len == 3` because for project scope the primary check is already the Project instance and the dedup skips `scope-parent`.
- [x] All other webhook tests pass.
- [ ] Manual verification on staging once deployed: the gateway / cloud-portal session delete that was 403ing should succeed.

## Companion PRs
- `datum-cloud/graphql-gateway#27` (merged) — gateway `Mutation.deleteSession` resolver that hits this path.
- `datum-cloud/cloud-portal#1218` — frontend "Revoke Session" button. Currently fails silently in production; this PR is what makes it actually work.