### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,10 +48,10 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.13.1
     with:
-      bundle-name: ghcr.io/datum-cloud/auth-provider-openfga-kustomize
+      bundle-name: ghcr.io/milo-os/openfga-provider-kustomize
       bundle-path: config
       image-overlays: config/base/services/authz-webhook,config/base/services/controller-manager
-      image-name: ghcr.io/datum-cloud/auth-provider-openfga
+      image-name: ghcr.io/milo-os/openfga-provider
       debug: true
     secrets: inherit
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Prepare local alias tag
         run: |
-          TAG="ghcr.io/datum-cloud/auth-provider-openfga:${{ needs.publish-container-image.outputs.tag }}"
+          TAG="ghcr.io/milo-os/openfga-provider:${{ needs.publish-container-image.outputs.tag }}"
           docker pull "$TAG"
           docker tag "$TAG" auth-provider-openfga:test
 
@@ -85,7 +85,7 @@ jobs:
           cluster_name: auth-provider-openfga         # optional override
           wait_timeout: "300s"                         # optional override
           images: |
-            ghcr.io/datum-cloud/auth-provider-openfga:${{ needs.publish-container-image.outputs.tag }}
+            ghcr.io/milo-os/openfga-provider:${{ needs.publish-container-image.outputs.tag }}
             auth-provider-openfga:test
 
       - name: Install Task
@@ -133,7 +133,7 @@ jobs:
             namespace: flux-system
           spec:
             interval: 30s
-            url: oci://ghcr.io/datum-cloud/auth-provider-openfga-kustomize
+            url: oci://ghcr.io/milo-os/openfga-provider-kustomize
             ref:
               tag: ${OCI_TAG}
           EOF

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,7 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
+      registry-organization: milo-os
       image-name: auth-provider-openfga
     secrets: inherit
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ resources.
 ## Overview
 
 This project provides the authorization backbone for the [Milo business
-operating system](https://github.com/datum-cloud/milo), which uses Kubernetes
+operating system](https://github.com/milo-os/milo), which uses Kubernetes
 APIServer patterns to manage business entities for product-led B2B companies.
 The auth provider bridges Milo's business APIs with OpenFGA's relationship-based
 authorization engine to answer complex business questions like:

--- a/config/base/services/authz-webhook/authz-webhook.yaml
+++ b/config/base/services/authz-webhook/authz-webhook.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: authz-webhook
-          image: ghcr.io/datum-cloud/auth-provider-openfga:latest
+          image: ghcr.io/milo-os/openfga-provider:latest
           imagePullPolicy: IfNotPresent
           args:
             - authz-webhook

--- a/config/base/services/controller-manager/manager.yaml
+++ b/config/base/services/controller-manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: manager
-        image: ghcr.io/datum-cloud/auth-provider-openfga:latest
+        image: ghcr.io/milo-os/openfga-provider:latest
         imagePullPolicy: IfNotPresent
         args:
           - manager

--- a/config/environments/local-development/kustomization.yaml
+++ b/config/environments/local-development/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 
 resources:
   # External CRDs from Milo API
-  - github.com/datum-cloud/milo/config/crd/overlays/core-control-plane
+  - github.com/milo-os/milo/config/crd/overlays/core-control-plane
   # Base application components
   - ../../base
   # Development-specific certificate issuers
@@ -21,6 +21,6 @@ components:
 
 # Development-specific image configurations
 images:
-  - name: ghcr.io/datum-cloud/auth-provider-openfga
+  - name: ghcr.io/milo-os/openfga-provider
     newName: auth-provider-openfga
     newTag: dev

--- a/config/environments/testing/kustomization.yaml
+++ b/config/environments/testing/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 
 resources:
   # External CRDs from Milo API
-  - github.com/datum-cloud/milo/config/crd/overlays/core-control-plane
+  - github.com/milo-os/milo/config/crd/overlays/core-control-plane
   # Base application components
   - ../../base
   # Testing-specific certificate issuers (same as dev for now)
@@ -24,6 +24,6 @@ components:
 
 # Testing-specific image configuration
 images:
-  - name: ghcr.io/datum-cloud/auth-provider-openfga
+  - name: ghcr.io/milo-os/openfga-provider
     newName: auth-provider-openfga
     newTag: dev


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.