### PR TITLE
Fix inherited-role permission propagation

### DIFF
--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -760,6 +760,18 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForRoleChange(ctx context
 		"roleName", changedRole.Name,
 		"roleNamespace", changedRole.Namespace)
 
+	// A PolicyBinding's baked permission tuples derive from the effective
+	// permissions of its bound Role, which include permissions inherited
+	// transitively. So a binding must be re-evaluated not only when its bound
+	// Role changes directly, but also when any Role it transitively inherits
+	// changes. Compute the set of bound Roles affected by this change (the
+	// changed Role plus every Role that inherits it).
+	affectedRoles, err := rolesDependentOnRole(ctx, r.Client, client.ObjectKey{Namespace: changedRole.Namespace, Name: changedRole.Name})
+	if err != nil {
+		log.Error(err, "failed to compute Roles dependent on changed Role", "roleName", changedRole.Name, "roleNamespace", changedRole.Namespace)
+		return []reconcile.Request{}
+	}
+
 	policyBindings := &iamdatumapiscomv1alpha1.PolicyBindingList{}
 	if err := r.List(ctx, policyBindings); err != nil {
 		log.Error(err, "failed to list PolicyBindings for Role change", "roleName", changedRole.Name, "roleNamespace", changedRole.Namespace)
@@ -768,9 +780,17 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForRoleChange(ctx context
 
 	requests := make([]reconcile.Request, 0)
 	for _, pb := range policyBindings.Items {
-		// A PolicyBinding should be re-evaluated if its RoleRef matches the changed Role. The RoleRef in PolicyBindingSpec
-		// contains Name and Namespace. An empty RoleRef.Namespace typically refers to a cluster-scoped Role.
-		if pb.Spec.RoleRef.Name == changedRole.Name && pb.Spec.RoleRef.Namespace == changedRole.Namespace {
+		// Resolve the bound Role. An empty RoleRef.Namespace defaults to the
+		// PolicyBinding's namespace.
+		roleNamespace := pb.Spec.RoleRef.Namespace
+		if roleNamespace == "" {
+			roleNamespace = pb.Namespace
+		}
+		boundRole := client.ObjectKey{Namespace: roleNamespace, Name: pb.Spec.RoleRef.Name}
+
+		// Re-evaluate the binding if its bound Role is the changed Role or
+		// transitively inherits it.
+		if _, ok := affectedRoles[boundRole]; ok {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      pb.Name,
@@ -779,6 +799,7 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForRoleChange(ctx context
 			})
 			log.V(1).Info("Enqueuing PolicyBinding due to relevant Role change",
 				"policyBindingName", pb.Name, "policyBindingNamespace", pb.Namespace,
+				"boundRoleName", boundRole.Name, "boundRoleNamespace", boundRole.Namespace,
 				"changedRoleName", changedRole.Name, "changedRoleNamespace", changedRole.Namespace)
 		}
 	}

--- a/internal/controller/role_controller.go
+++ b/internal/controller/role_controller.go
@@ -16,10 +16,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -344,6 +346,41 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	return ctrl.Result{}, nil
 }
 
+// enqueueRequestsForInheritedRoleChange is a handler that enqueues reconcile
+// requests for every Role that transitively inherits the changed Role. A Role's
+// effective permissions are computed from its inherited Roles, so when an
+// inherited (ancestor) Role's permissions change, the descendant Roles must be
+// re-reconciled to refresh their Status.EffectivePermissions. The changed Role
+// itself is reconciled via the primary For() watch and is skipped here.
+func (r *RoleReconciler) enqueueRequestsForInheritedRoleChange(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := logf.FromContext(ctx)
+	changedRole, ok := obj.(*iamdatumapiscomv1alpha1.Role)
+	if !ok {
+		log.Error(fmt.Errorf("unexpected object type in Role handler for Roles: %T", obj), "cannot enqueue Roles")
+		return []reconcile.Request{}
+	}
+
+	changedKey := client.ObjectKey{Namespace: changedRole.Namespace, Name: changedRole.Name}
+	dependents, err := rolesDependentOnRole(ctx, r.Client, changedKey)
+	if err != nil {
+		log.Error(err, "failed to compute Roles dependent on changed Role",
+			"roleName", changedRole.Name, "roleNamespace", changedRole.Namespace)
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0, len(dependents))
+	for key := range dependents {
+		if key == changedKey {
+			continue // reconciled via the primary For() watch
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: key})
+		log.V(1).Info("Enqueuing Role due to inherited Role change",
+			"roleName", key.Name, "roleNamespace", key.Namespace,
+			"changedRoleName", changedRole.Name, "changedRoleNamespace", changedRole.Namespace)
+	}
+	return requests
+}
+
 // enqueueRequestsForProtectedResourceChange is a handler that enqueues Role reconcile requests
 // when a ProtectedResource changes.
 func (r *RoleReconciler) enqueueRequestsForProtectedResourceChange(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -419,6 +456,16 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder.Watches(
 		&iamdatumapiscomv1alpha1.ProtectedResource{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForProtectedResourceChange),
+	)
+
+	// Watch for changes to other Roles and enqueue the Roles that inherit them,
+	// so descendant Roles refresh their effective permissions when an inherited
+	// (ancestor) Role's permissions change. Filtered to spec changes
+	// (generation bumps) to avoid reacting to our own status updates.
+	controllerBuilder.Watches(
+		&iamdatumapiscomv1alpha1.Role{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForInheritedRoleChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	return controllerBuilder.Complete(r)

--- a/internal/controller/role_inheritance.go
+++ b/internal/controller/role_inheritance.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"context"
+
+	iamdatumapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// rolesDependentOnRole returns the set of Roles whose effective permissions
+// depend on the given (changed) Role: the changed Role itself plus every Role
+// that transitively inherits it via spec.inheritedRoles.
+//
+// It performs a single List of all Roles and walks the reverse inheritance
+// graph breadth-first, guarding against cycles. An inherited role reference
+// with an empty namespace defaults to the referencing Role's namespace,
+// mirroring getAllEffectivePermissions.
+//
+// This is the basis for propagating an inherited (ancestor) Role's permission
+// changes down to the descendant Roles that inherit it and to the
+// PolicyBindings bound to those descendants.
+func rolesDependentOnRole(ctx context.Context, c client.Client, changed client.ObjectKey) (map[client.ObjectKey]struct{}, error) {
+	roleList := &iamdatumapiscomv1alpha1.RoleList{}
+	if err := c.List(ctx, roleList); err != nil {
+		return nil, err
+	}
+
+	// reverse[parent] holds the Roles that directly inherit parent.
+	reverse := make(map[client.ObjectKey][]client.ObjectKey, len(roleList.Items))
+	for i := range roleList.Items {
+		child := &roleList.Items[i]
+		childKey := client.ObjectKey{Namespace: child.Namespace, Name: child.Name}
+		for _, ref := range child.Spec.InheritedRoles {
+			namespace := ref.Namespace
+			if namespace == "" {
+				namespace = child.Namespace
+			}
+			parentKey := client.ObjectKey{Namespace: namespace, Name: ref.Name}
+			reverse[parentKey] = append(reverse[parentKey], childKey)
+		}
+	}
+
+	dependents := map[client.ObjectKey]struct{}{changed: {}}
+	queue := []client.ObjectKey{changed}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		for _, childKey := range reverse[current] {
+			if _, seen := dependents[childKey]; !seen {
+				dependents[childKey] = struct{}{}
+				queue = append(queue, childKey)
+			}
+		}
+	}
+
+	return dependents, nil
+}

--- a/internal/controller/role_inheritance_test.go
+++ b/internal/controller/role_inheritance_test.go
@@ -1,0 +1,128 @@
+package controller
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	iamdatumapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func role(namespace, name string, inherited ...iamdatumapiscomv1alpha1.ScopedRoleReference) *iamdatumapiscomv1alpha1.Role {
+	return &iamdatumapiscomv1alpha1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       iamdatumapiscomv1alpha1.RoleSpec{InheritedRoles: inherited},
+	}
+}
+
+func inherits(name, namespace string) iamdatumapiscomv1alpha1.ScopedRoleReference {
+	return iamdatumapiscomv1alpha1.ScopedRoleReference{Name: name, Namespace: namespace}
+}
+
+func keys(set map[client.ObjectKey]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k.Namespace+"/"+k.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestRolesDependentOnRole(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := iamdatumapiscomv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		roles   []*iamdatumapiscomv1alpha1.Role
+		changed client.ObjectKey
+		want    []string
+	}{
+		{
+			name: "transitive chain across namespaces resolves full closure",
+			roles: []*iamdatumapiscomv1alpha1.Role{
+				// viewer (datum-cloud) -> networking-viewer (milo-system) -> gateway-viewer (milo-system)
+				role("datum-cloud", "viewer", inherits("networking-viewer", "milo-system")),
+				role("milo-system", "networking-viewer", inherits("gateway-viewer", "")),
+				role("milo-system", "gateway-viewer"),
+			},
+			changed: client.ObjectKey{Namespace: "milo-system", Name: "gateway-viewer"},
+			want: []string{
+				"datum-cloud/viewer",
+				"milo-system/gateway-viewer", // the changed role itself is included
+				"milo-system/networking-viewer",
+			},
+		},
+		{
+			name: "empty inherited namespace defaults to the referencing role namespace",
+			roles: []*iamdatumapiscomv1alpha1.Role{
+				role("ns-a", "child", inherits("parent", "")),
+				role("ns-a", "parent"),
+				// Same-named parent in another namespace must NOT be matched.
+				role("ns-b", "parent"),
+			},
+			changed: client.ObjectKey{Namespace: "ns-a", Name: "parent"},
+			want:    []string{"ns-a/child", "ns-a/parent"},
+		},
+		{
+			name: "cycle does not loop forever",
+			roles: []*iamdatumapiscomv1alpha1.Role{
+				role("ns", "a", inherits("b", "ns")),
+				role("ns", "b", inherits("a", "ns")),
+			},
+			changed: client.ObjectKey{Namespace: "ns", Name: "a"},
+			want:    []string{"ns/a", "ns/b"},
+		},
+		{
+			name: "role with no dependents returns only itself",
+			roles: []*iamdatumapiscomv1alpha1.Role{
+				role("ns", "lonely"),
+				role("ns", "unrelated", inherits("something-else", "ns")),
+			},
+			changed: client.ObjectKey{Namespace: "ns", Name: "lonely"},
+			want:    []string{"ns/lonely"},
+		},
+		{
+			name: "diamond inheritance is de-duplicated",
+			roles: []*iamdatumapiscomv1alpha1.Role{
+				role("ns", "top"),
+				role("ns", "left", inherits("top", "ns")),
+				role("ns", "right", inherits("top", "ns")),
+				role("ns", "bottom", inherits("left", "ns"), inherits("right", "ns")),
+			},
+			changed: client.ObjectKey{Namespace: "ns", Name: "top"},
+			want:    []string{"ns/bottom", "ns/left", "ns/right", "ns/top"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]client.Object, 0, len(tt.roles))
+			for _, r := range tt.roles {
+				objs = append(objs, r)
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+			got, err := rolesDependentOnRole(context.Background(), c, tt.changed)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotKeys := keys(got)
+			if len(gotKeys) != len(tt.want) {
+				t.Fatalf("got %v, want %v", gotKeys, tt.want)
+			}
+			for i := range tt.want {
+				if gotKeys[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", gotKeys, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/test/iam/role-inheritance-propagation/chainsaw-test.yaml
+++ b/test/iam/role-inheritance-propagation/chainsaw-test.yaml
@@ -1,0 +1,330 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: role-inheritance-propagation
+# Regression test for inherited-role permission propagation.
+#
+# Scenario (mirrors datum-cloud-viewer -> networking-viewer -> gateway-viewer):
+# a subject is bound to the leaf role of a 3-level inheritance chain. After the
+# top role of the chain gains a new permission, that permission must propagate
+#   1. to the leaf Role's status.effectivePermissions (role controller re-reconciles
+#      descendants when an inherited role changes), and
+#   2. to the live authorization decision for the bound subject (the PolicyBinding
+#      tuples are re-baked).
+#
+# Before the fix, the leaf role's effective permissions went stale and the subject
+# kept getting denied on the newly added permission, so steps (1) and (2) below
+# would time out.
+spec:
+  steps:
+    # --- Build the inheritance chain: gateway-viewer <- networking-viewer <- org-viewer ---
+    - try:
+        - apply:
+            file: roles/gateway-viewer.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: Role
+            name: inheritance-gateway-viewer
+            timeout: 5m
+            for:
+              condition:
+                name: Ready
+                value: "true"
+        - apply:
+            file: roles/networking-viewer.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: Role
+            name: inheritance-networking-viewer
+            timeout: 5m
+            for:
+              condition:
+                name: Ready
+                value: "true"
+        - apply:
+            file: roles/org-viewer.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: Role
+            name: inheritance-org-viewer
+            timeout: 5m
+            for:
+              condition:
+                name: Ready
+                value: "true"
+
+    # --- Baseline: the leaf role inherits exactly the top role's two permissions ---
+    - try:
+        - assert:
+            timeout: 2m
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: Role
+              metadata:
+                name: inheritance-org-viewer
+              status:
+                (length(effectivePermissions)): 2
+                effectivePermissions:
+                  - resourcemanager.miloapis.com/organizations.get
+                  - resourcemanager.miloapis.com/organizations.list
+
+    # --- Bind a user to the leaf role on Organization "role-inheritance-test-org" ---
+    - try:
+        - create:
+            file: user.yaml
+            outputs:
+              - name: user
+                value: (@)
+        - create:
+            file: organization.yaml
+            outputs:
+              - name: org
+                value: (@)
+        - apply:
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: PolicyBinding
+              metadata:
+                name: inheritance-org-viewer-binding
+              spec:
+                roleRef:
+                  name: inheritance-org-viewer
+                  namespace: ($namespace)
+                subjects:
+                  - kind: User
+                    name: "inheritance-viewer-user"
+                    uid: ($user.metadata.uid)
+                resourceSelector:
+                  resourceRef:
+                    apiGroup: "resourcemanager.miloapis.com"
+                    kind: Organization
+                    name: "role-inheritance-test-org"
+                    uid: ($org.metadata.uid)
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: PolicyBinding
+            name: inheritance-org-viewer-binding
+            timeout: 5m
+            for:
+              condition:
+                name: Ready
+                value: "true"
+
+    # --- Baseline authorization: inherited "get" is allowed ---
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: sar-get-allowed
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: curl
+                  image: curlimages/curl:latest
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      response=$(curl -ksS https://auth-provider-openfga-authz-webhook.auth-provider-openfga-system.svc.cluster.local:8090/apis/authorization.k8s.io/v1/subjectaccessreviews \
+                        -H "Content-Type: application/json" \
+                        -d @- << EOF
+                      {
+                        "apiVersion": "authorization.k8s.io/v1",
+                        "kind": "SubjectAccessReview",
+                        "spec": {
+                          "user": "inheritance-viewer-user",
+                          "uid": "inheritance-viewer-user",
+                          "extra": {
+                            "resourcemanager.miloapis.com/organization-id": ["role-inheritance-test-org"]
+                          },
+                          "groups": ["system:authenticated"],
+                          "resourceAttributes": {
+                            "group": "resourcemanager.miloapis.com",
+                            "resource": "organizations",
+                            "version": "v1alpha1",
+                            "verb": "get",
+                            "name": "role-inheritance-test-org"
+                          }
+                        }
+                      }
+                      EOF
+                      )
+                      echo "Webhook response: $response"
+                      if ! echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                        echo "Webhook test failed - invalid response format"
+                        exit 1
+                      fi
+                      if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+                        echo "Baseline get allowed - OK"
+                        exit 0
+                      else
+                        echo "Baseline get should have been allowed"
+                        exit 1
+                      fi
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: sar-get-allowed
+            timeout: 30s
+            for:
+              jsonPath:
+                path: "status.phase"
+                value: "Succeeded"
+
+    # --- Before the change: "update" (not yet in the chain) is denied ---
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: sar-update-denied
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: curl
+                  image: curlimages/curl:latest
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      response=$(curl -ksS https://auth-provider-openfga-authz-webhook.auth-provider-openfga-system.svc.cluster.local:8090/apis/authorization.k8s.io/v1/subjectaccessreviews \
+                        -H "Content-Type: application/json" \
+                        -d @- << EOF
+                      {
+                        "apiVersion": "authorization.k8s.io/v1",
+                        "kind": "SubjectAccessReview",
+                        "spec": {
+                          "user": "inheritance-viewer-user",
+                          "uid": "inheritance-viewer-user",
+                          "extra": {
+                            "resourcemanager.miloapis.com/organization-id": ["role-inheritance-test-org"]
+                          },
+                          "groups": ["system:authenticated"],
+                          "resourceAttributes": {
+                            "group": "resourcemanager.miloapis.com",
+                            "resource": "organizations",
+                            "version": "v1alpha1",
+                            "verb": "update",
+                            "name": "role-inheritance-test-org"
+                          }
+                        }
+                      }
+                      EOF
+                      )
+                      echo "Webhook response: $response"
+                      if ! echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                        echo "Webhook test failed - invalid response format"
+                        exit 1
+                      fi
+                      if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*false'; then
+                        echo "Update correctly denied before the permission was added - OK"
+                        exit 0
+                      else
+                        echo "Update should have been denied before the permission was added"
+                        exit 1
+                      fi
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: sar-update-denied
+            timeout: 30s
+            for:
+              jsonPath:
+                path: "status.phase"
+                value: "Succeeded"
+
+    # --- Mutate the TOP of the chain: add organizations.update to gateway-viewer ---
+    - try:
+        - apply:
+            file: roles/gateway-viewer-updated.yaml
+        - assert:
+            timeout: 2m
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: Role
+              metadata:
+                name: inheritance-gateway-viewer
+              status:
+                (length(effectivePermissions)): 3
+                effectivePermissions:
+                  - resourcemanager.miloapis.com/organizations.get
+                  - resourcemanager.miloapis.com/organizations.list
+                  - resourcemanager.miloapis.com/organizations.update
+
+    # --- Gap A: the new permission propagates to the LEAF role's effective permissions ---
+    - try:
+        - assert:
+            timeout: 2m
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: Role
+              metadata:
+                name: inheritance-org-viewer
+              status:
+                (length(effectivePermissions)): 3
+                effectivePermissions:
+                  - resourcemanager.miloapis.com/organizations.get
+                  - resourcemanager.miloapis.com/organizations.list
+                  - resourcemanager.miloapis.com/organizations.update
+
+    # --- Gap B: the bound subject is now allowed to "update" (tuples were re-baked) ---
+    - try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: sar-update-allowed
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: curl
+                  image: curlimages/curl:latest
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      # The tuple re-bake is asynchronous; retry until OpenFGA reflects it.
+                      for i in $(seq 1 30); do
+                        response=$(curl -ksS https://auth-provider-openfga-authz-webhook.auth-provider-openfga-system.svc.cluster.local:8090/apis/authorization.k8s.io/v1/subjectaccessreviews \
+                          -H "Content-Type: application/json" \
+                          -d @- << EOF
+                      {
+                        "apiVersion": "authorization.k8s.io/v1",
+                        "kind": "SubjectAccessReview",
+                        "spec": {
+                          "user": "inheritance-viewer-user",
+                          "uid": "inheritance-viewer-user",
+                          "extra": {
+                            "resourcemanager.miloapis.com/organization-id": ["role-inheritance-test-org"]
+                          },
+                          "groups": ["system:authenticated"],
+                          "resourceAttributes": {
+                            "group": "resourcemanager.miloapis.com",
+                            "resource": "organizations",
+                            "version": "v1alpha1",
+                            "verb": "update",
+                            "name": "role-inheritance-test-org"
+                          }
+                        }
+                      }
+                      EOF
+                        )
+                        echo "Attempt $i webhook response: $response"
+                        if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+                          echo "Update allowed after permission propagated - OK"
+                          exit 0
+                        fi
+                        sleep 5
+                      done
+                      echo "Update was never allowed after the permission was added to the inherited role"
+                      exit 1
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: sar-update-allowed
+            timeout: 3m
+            for:
+              jsonPath:
+                path: "status.phase"
+                value: "Succeeded"

--- a/test/iam/role-inheritance-propagation/organization.yaml
+++ b/test/iam/role-inheritance-propagation/organization.yaml
@@ -1,0 +1,6 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: role-inheritance-test-org
+spec:
+  type: Standard

--- a/test/iam/role-inheritance-propagation/roles/gateway-viewer-updated.yaml
+++ b/test/iam/role-inheritance-propagation/roles/gateway-viewer-updated.yaml
@@ -1,0 +1,13 @@
+# Same role as gateway-viewer.yaml with an additional permission
+# (organizations.update). Applying this mutates the top of the chain and must
+# propagate down to every descendant Role and to the bound PolicyBinding.
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: inheritance-gateway-viewer
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - resourcemanager.miloapis.com/organizations.get
+    - resourcemanager.miloapis.com/organizations.list
+    - resourcemanager.miloapis.com/organizations.update

--- a/test/iam/role-inheritance-propagation/roles/gateway-viewer.yaml
+++ b/test/iam/role-inheritance-propagation/roles/gateway-viewer.yaml
@@ -1,0 +1,12 @@
+# Top of the inheritance chain (analogous to networking gateway-viewer).
+# Starts with two organization permissions; the test later adds a third
+# (organizations.update) to verify the change propagates to descendants.
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: inheritance-gateway-viewer
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - resourcemanager.miloapis.com/organizations.get
+    - resourcemanager.miloapis.com/organizations.list

--- a/test/iam/role-inheritance-propagation/roles/networking-viewer.yaml
+++ b/test/iam/role-inheritance-propagation/roles/networking-viewer.yaml
@@ -1,0 +1,11 @@
+# Middle of the chain (analogous to networking.datumapis.com-viewer).
+# Inherit-only: all of its effective permissions come from gateway-viewer.
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: inheritance-networking-viewer
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: inheritance-gateway-viewer
+      namespace: ($namespace)

--- a/test/iam/role-inheritance-propagation/roles/org-viewer.yaml
+++ b/test/iam/role-inheritance-propagation/roles/org-viewer.yaml
@@ -1,0 +1,12 @@
+# Leaf of the chain (analogous to datum-cloud-viewer) and the role that is
+# actually bound to a subject. Inherits the middle role, which inherits the top
+# role, so a change at the top must reach this role's effective permissions.
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: inheritance-org-viewer
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: inheritance-networking-viewer
+      namespace: ($namespace)

--- a/test/iam/role-inheritance-propagation/user.yaml
+++ b/test/iam/role-inheritance-propagation/user.yaml
@@ -1,0 +1,6 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: inheritance-viewer-user
+spec:
+  email: inheritance-viewer-user@datum.net


### PR DESCRIPTION
## Problem

A Role's effective permissions are computed transitively from its inheritedRoles, but the controllers never reacted when an inherited (ancestor) Role changed. When a permission was added to a parent role, descendant roles kept stale status.effectivePermissions and the PolicyBinding tuples baked from them were never refreshed — so bound subjects kept getting 403 on the new permission indefinitely.

This is the root cause of milo-os/openfga-provider#111 (datum-cloud-viewer 403s on trafficprotectionpolicies but 200s on httpproxies — same chain, the WAF perm was added to gateway-viewer after the tuples were last baked).

### Changes

- Role controller — added a `Role → Role` watch (filtered to spec changes) that re-reconciles every Role transitively inheriting a changed Role, refreshing their effective permissions.
- PolicyBinding controller — the role-change handler now re-enqueues bindings whose bound Role is anywhere in the changed Role's inheritance closure (not just a direct `RoleRef` match), and applies RoleRef namespace defaulting. This re-bakes the OpenFGA tuples.
- Shared `rolesDependentOnRole` helper (reverse inheritance closure, cycle-guarded, namespace-aware) backs both watches.
