### PR TITLE
fix(role): degrade gracefully on unresolved inheritedRoles

### DIFF
--- a/internal/controller/role_controller.go
+++ b/internal/controller/role_controller.go
@@ -80,15 +80,38 @@ type RoleReconciler struct {
 	EventRecorder record.EventRecorder
 }
 
-// getAllEffectivePermissions collects all unique permissions for a role, including inherited ones.
-func (r *RoleReconciler) getAllEffectivePermissions(ctx context.Context, role *iamdatumapiscomv1alpha1.Role, visited map[string]struct{}) ([]string, error) {
+// unresolvedInheritedRole identifies an inheritedRoles reference that could not
+// be resolved to an existing Role during effective-permission computation.
+type unresolvedInheritedRole struct {
+	Namespace string
+	Name      string
+}
+
+// String renders the reference as "namespace/name" for log, condition, and
+// event messages.
+func (u unresolvedInheritedRole) String() string {
+	return u.Namespace + "/" + u.Name
+}
+
+// getAllEffectivePermissions collects all unique permissions for a role,
+// including those reachable through inheritedRoles.
+//
+// The computation degrades gracefully: a reference to a Role that does not
+// exist yet is recorded in the returned unresolved slice and skipped, rather
+// than failing the whole computation. This keeps a broadly-inherited role
+// (such as a project owner) granting every permission it can resolve while a
+// single dangling reference converges. The function only returns an error for
+// genuine failures (for example, a non-NotFound API error). Callers that want
+// fail-closed behavior must treat a non-empty unresolved slice as a degraded
+// state and surface it.
+func (r *RoleReconciler) getAllEffectivePermissions(ctx context.Context, role *iamdatumapiscomv1alpha1.Role, visited map[string]struct{}) ([]string, []unresolvedInheritedRole, error) {
 	if visited == nil {
 		visited = make(map[string]struct{})
 	}
 
 	roleIdentifier := role.Namespace + "/" + role.Name // Ensure uniqueness for visited roles across namespaces
 	if _, ok := visited[roleIdentifier]; ok {
-		return nil, nil // Prevent cycles
+		return nil, nil, nil // Prevent cycles
 	}
 	visited[roleIdentifier] = struct{}{}
 
@@ -97,6 +120,7 @@ func (r *RoleReconciler) getAllEffectivePermissions(ctx context.Context, role *i
 		permissionSet[p] = struct{}{}
 	}
 
+	var unresolved []unresolvedInheritedRole
 	for _, inheritedRoleRef := range role.Spec.InheritedRoles {
 		inheritedRole := &iamdatumapiscomv1alpha1.Role{}
 
@@ -110,25 +134,145 @@ func (r *RoleReconciler) getAllEffectivePermissions(ctx context.Context, role *i
 		err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: inheritedRoleRef.Name}, inheritedRole)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("inherited role '%s' not found in namespace '%s'", inheritedRoleRef.Name, namespace)
+				// Degrade gracefully: skip the dangling reference (fail-closed
+				// on its permissions) and report it so the caller can surface a
+				// Degraded condition. Do not fail the whole role.
+				unresolved = append(unresolved, unresolvedInheritedRole{Namespace: namespace, Name: inheritedRoleRef.Name})
+				continue
 			}
-			return nil, fmt.Errorf("failed to get inherited role %s/%s: %w", namespace, inheritedRoleRef.Name, err)
+			return nil, nil, fmt.Errorf("failed to get inherited role %s/%s: %w", namespace, inheritedRoleRef.Name, err)
 		}
 
-		inheritedPerms, err := r.getAllEffectivePermissions(ctx, inheritedRole, visited)
+		inheritedPerms, inheritedUnresolved, err := r.getAllEffectivePermissions(ctx, inheritedRole, visited)
 		if err != nil {
-			return nil, err // Propagate error up
+			return nil, nil, err // Propagate genuine errors up
 		}
 		for _, p := range inheritedPerms {
 			permissionSet[p] = struct{}{}
 		}
+		unresolved = append(unresolved, inheritedUnresolved...)
 	}
 
 	finalPermissions := make([]string, 0, len(permissionSet))
 	for p := range permissionSet {
 		finalPermissions = append(finalPermissions, p)
 	}
-	return finalPermissions, nil
+	return finalPermissions, dedupeUnresolved(unresolved), nil
+}
+
+// dedupeUnresolved removes duplicate unresolved references (a diamond-shaped
+// inheritance graph can surface the same dangling reference more than once) and
+// returns them in a deterministic order for stable conditions and events.
+func dedupeUnresolved(refs []unresolvedInheritedRole) []unresolvedInheritedRole {
+	if len(refs) == 0 {
+		return nil
+	}
+	seen := make(map[unresolvedInheritedRole]struct{}, len(refs))
+	deduped := make([]unresolvedInheritedRole, 0, len(refs))
+	for _, ref := range refs {
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		deduped = append(deduped, ref)
+	}
+	sort.Slice(deduped, func(i, j int) bool {
+		if deduped[i].Namespace != deduped[j].Namespace {
+			return deduped[i].Namespace < deduped[j].Namespace
+		}
+		return deduped[i].Name < deduped[j].Name
+	})
+	return deduped
+}
+
+// unresolvedRefStrings renders unresolved references as "namespace/name"
+// strings for structured logging.
+func unresolvedRefStrings(refs []unresolvedInheritedRole) []string {
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, ref.String())
+	}
+	return out
+}
+
+// unresolvedMessage builds a human-readable condition/event message naming the
+// exact unresolved inheritedRoles references.
+func unresolvedMessage(refs []unresolvedInheritedRole) string {
+	return fmt.Sprintf("Role is degraded: permissions from resolvable inherited roles are applied, but %d inheritedRoles reference(s) could not be resolved: %s",
+		len(refs), strings.Join(unresolvedRefStrings(refs), ", "))
+}
+
+// setDegradedCondition records the Degraded condition and a Warning event when
+// the role has unresolved inheritedRoles references, and clears the condition
+// once every reference resolves.
+func (r *RoleReconciler) setDegradedCondition(ctx context.Context, role *iamdatumapiscomv1alpha1.Role, unresolvedRoles []unresolvedInheritedRole, generation int64) {
+	if len(unresolvedRoles) == 0 {
+		meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
+			Type:               "Degraded",
+			Status:             metav1.ConditionFalse,
+			Reason:             "AllInheritedRolesResolved",
+			Message:            "All inheritedRoles references resolved.",
+			ObservedGeneration: generation,
+		})
+		return
+	}
+
+	message := unresolvedMessage(unresolvedRoles)
+	meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
+		Type:               "Degraded",
+		Status:             metav1.ConditionTrue,
+		Reason:             "UnresolvedInheritedRoles",
+		Message:            message,
+		ObservedGeneration: generation,
+	})
+	if r.EventRecorder != nil {
+		r.EventRecorder.Event(role, "Warning", "UnresolvedInheritedRoles", message)
+	}
+}
+
+// enqueueRequestsForInheritedRoleChange enqueues every Role that inherits the
+// changed Role. When a previously-missing inherited role is created, its
+// dependents reconcile promptly and converge to fully-Ready instead of waiting
+// out an exponential backoff.
+func (r *RoleReconciler) enqueueRequestsForInheritedRoleChange(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := logf.FromContext(ctx)
+	changedRole, ok := obj.(*iamdatumapiscomv1alpha1.Role)
+	if !ok {
+		log.Error(fmt.Errorf("unexpected object type in Role inheritance handler: %T", obj), "cannot enqueue Roles")
+		return []reconcile.Request{}
+	}
+
+	roleList := &iamdatumapiscomv1alpha1.RoleList{}
+	if err := r.List(ctx, roleList); err != nil {
+		log.Error(err, "failed to list Roles for inherited-role change handler")
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for i := range roleList.Items {
+		dependent := &roleList.Items[i]
+		// The role's own changes are already handled by the primary For()
+		// watch; only enqueue other roles that inherit it.
+		if dependent.Namespace == changedRole.Namespace && dependent.Name == changedRole.Name {
+			continue
+		}
+		for _, ref := range dependent.Spec.InheritedRoles {
+			refNamespace := dependent.Namespace
+			if ref.Namespace != "" {
+				refNamespace = ref.Namespace
+			}
+			if refNamespace == changedRole.Namespace && ref.Name == changedRole.Name {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKey{Name: dependent.Name, Namespace: dependent.Namespace},
+				})
+				log.V(1).Info("Enqueuing Role due to inherited Role change",
+					"roleName", dependent.Name, "roleNamespace", dependent.Namespace,
+					"changedRole", changedRole.Namespace+"/"+changedRole.Name)
+				break
+			}
+		}
+	}
+	return requests
 }
 
 // validateRolePermissions checks if all effective permissions in a role are validly defined by known ProtectedResources.
@@ -175,7 +319,10 @@ func (r *RoleReconciler) isRoleAffectedByProtectedResource(ctx context.Context, 
 		"serviceRef", pr.Spec.ServiceRef.Name, "kindDefined", pr.Spec.Kind,
 	)
 
-	effectivePermissions, err := r.getAllEffectivePermissions(ctx, role, nil)
+	// Unresolved inherited references are ignored here: a degraded role can
+	// still be affected by a ProtectedResource change through the permissions
+	// it does resolve.
+	effectivePermissions, _, err := r.getAllEffectivePermissions(ctx, role, nil)
 	if err != nil {
 		roleLog.V(1).Info("Could not get effective permissions for role, cannot determine if affected by ProtectedResource change", "error", err.Error())
 		return false, err
@@ -257,9 +404,15 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// Compute effective permissions once for both status population and validation
-	effectivePermissions, effectivePermsErr := r.getAllEffectivePermissions(ctx, role, nil)
+	// Compute effective permissions once for both status population and
+	// validation. Unresolved inheritedRoles references degrade the role
+	// gracefully (the resolvable permissions are still applied) instead of
+	// zeroing out every permission the role grants.
+	effectivePermissions, unresolvedRoles, effectivePermsErr := r.getAllEffectivePermissions(ctx, role, nil)
 	if effectivePermsErr != nil {
+		// Only genuine errors (for example, a non-NotFound API failure) reach
+		// here; a missing inherited role is reported via unresolvedRoles
+		// instead. Retry with backoff for the transient failure.
 		log.Error(effectivePermsErr, "Failed to compute effective permissions for role")
 		meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
@@ -276,6 +429,13 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Sort for deterministic output and populate status
 	sort.Strings(effectivePermissions)
 	role.Status.EffectivePermissions = effectivePermissions
+
+	// Record the degraded state (if any) as a dedicated condition and event so
+	// an unresolved reference is immediately diagnosable on the Role itself,
+	// rather than manifesting as mystery Forbidden errors on unrelated
+	// resources. The Degraded condition is set regardless of whether OpenFGA
+	// reconciliation proceeds below.
+	r.setDegradedCondition(ctx, role, unresolvedRoles, currentGeneration)
 
 	invalidPermissions, validationErr := r.validateRolePermissions(ctx, role, protectedResourceList.Items, effectivePermissions)
 	permValidationCondition := metav1.Condition{
@@ -317,14 +477,30 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			}
 			return ctrl.Result{}, err
 		}
-		log.Info("Role successfully reconciled with OpenFGA")
-		meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
-			Type:               "Ready",
-			Status:             metav1.ConditionTrue,
-			Reason:             "ReconciliationSuccessful",
-			Message:            "Role reconciled successfully with OpenFGA.",
-			ObservedGeneration: currentGeneration,
-		})
+		if len(unresolvedRoles) > 0 {
+			// Resolvable permissions were applied to OpenFGA, but the role is
+			// not fully Ready until every inherited reference resolves. Stay
+			// non-Ready (and Degraded) so the misconfiguration is visible and
+			// so the role converges to fully-Ready once the reference appears.
+			log.Info("Role reconciled with OpenFGA in a degraded state due to unresolved inherited roles",
+				"unresolvedInheritedRoles", unresolvedRefStrings(unresolvedRoles))
+			meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "UnresolvedInheritedRoles",
+				Message:            unresolvedMessage(unresolvedRoles),
+				ObservedGeneration: currentGeneration,
+			})
+		} else {
+			log.Info("Role successfully reconciled with OpenFGA")
+			meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				Reason:             "ReconciliationSuccessful",
+				Message:            "Role reconciled successfully with OpenFGA.",
+				ObservedGeneration: currentGeneration,
+			})
+		}
 	} else {
 		log.Info("Skipping OpenFGA reconciliation due to invalid permissions.")
 		meta.SetStatusCondition(&role.Status.Conditions, metav1.Condition{
@@ -419,6 +595,14 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder.Watches(
 		&iamdatumapiscomv1alpha1.ProtectedResource{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForProtectedResourceChange),
+	)
+
+	// Watch Roles so that when a previously-missing inherited Role appears, the
+	// Roles that inherit it reconcile promptly and converge without waiting out
+	// the controller's exponential backoff.
+	controllerBuilder.Watches(
+		&iamdatumapiscomv1alpha1.Role{},
+		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForInheritedRoleChange),
 	)
 
 	return controllerBuilder.Complete(r)

--- a/internal/controller/role_controller_degradation_test.go
+++ b/internal/controller/role_controller_degradation_test.go
@@ -1,0 +1,160 @@
+package controller
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func degradationScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := iamv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add iam scheme: %v", err)
+	}
+	return s
+}
+
+func role(namespace, name string, included []string, inherited ...iamv1alpha1.ScopedRoleReference) *iamv1alpha1.Role {
+	return &iamv1alpha1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: iamv1alpha1.RoleSpec{
+			IncludedPermissions: included,
+			InheritedRoles:      inherited,
+		},
+	}
+}
+
+func newRoleReconciler(t *testing.T, objs ...client.Object) *RoleReconciler {
+	t.Helper()
+	s := degradationScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return &RoleReconciler{Client: c, Scheme: s}
+}
+
+// One unresolvable inheritedRoles entry must not zero out the rest: the
+// resolvable inherited permissions plus the role's own permissions are still
+// returned, and the dangling reference is reported.
+func TestGetAllEffectivePermissions_DegradesGracefully(t *testing.T) {
+	resolvable := role("org-x", "viewer", []string{"svc.miloapis.com/widgets.get"})
+	owner := role("org-x", "owner",
+		[]string{"svc.miloapis.com/widgets.create"},
+		iamv1alpha1.ScopedRoleReference{Name: "viewer"},
+		iamv1alpha1.ScopedRoleReference{Name: "missing-role"},
+	)
+
+	r := newRoleReconciler(t, resolvable, owner)
+
+	perms, unresolved, err := r.getAllEffectivePermissions(context.Background(), owner, nil)
+	if err != nil {
+		t.Fatalf("expected no error for missing inherited role, got %v", err)
+	}
+
+	sort.Strings(perms)
+	want := []string{"svc.miloapis.com/widgets.create", "svc.miloapis.com/widgets.get"}
+	if len(perms) != len(want) || perms[0] != want[0] || perms[1] != want[1] {
+		t.Fatalf("expected resolvable permissions %v, got %v", want, perms)
+	}
+
+	if len(unresolved) != 1 {
+		t.Fatalf("expected 1 unresolved reference, got %d: %v", len(unresolved), unresolved)
+	}
+	if unresolved[0].Name != "missing-role" || unresolved[0].Namespace != "org-x" {
+		t.Fatalf("expected unresolved org-x/missing-role, got %s", unresolved[0].String())
+	}
+}
+
+// When every inherited role resolves, no unresolved references are reported.
+func TestGetAllEffectivePermissions_FullyResolved(t *testing.T) {
+	base := role("org-x", "viewer", []string{"svc.miloapis.com/widgets.get"})
+	owner := role("org-x", "owner", nil, iamv1alpha1.ScopedRoleReference{Name: "viewer"})
+
+	r := newRoleReconciler(t, base, owner)
+
+	perms, unresolved, err := r.getAllEffectivePermissions(context.Background(), owner, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(unresolved) != 0 {
+		t.Fatalf("expected no unresolved references, got %v", unresolved)
+	}
+	if len(perms) != 1 || perms[0] != "svc.miloapis.com/widgets.get" {
+		t.Fatalf("expected inherited permission applied, got %v", perms)
+	}
+}
+
+// dedupeUnresolved collapses a dangling reference reachable via multiple
+// inheritance paths into a single, deterministically ordered entry.
+func TestDedupeUnresolved(t *testing.T) {
+	got := dedupeUnresolved([]unresolvedInheritedRole{
+		{Namespace: "b", Name: "two"},
+		{Namespace: "a", Name: "one"},
+		{Namespace: "b", Name: "two"},
+	})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unique references, got %d: %v", len(got), got)
+	}
+	if got[0].String() != "a/one" || got[1].String() != "b/two" {
+		t.Fatalf("expected sorted [a/one b/two], got %v", got)
+	}
+}
+
+// setDegradedCondition surfaces a Degraded=True condition naming the unresolved
+// reference, and clears it once references resolve.
+func TestSetDegradedCondition(t *testing.T) {
+	r := &RoleReconciler{}
+	rl := role("org-x", "owner", nil)
+
+	r.setDegradedCondition(context.Background(), rl, []unresolvedInheritedRole{{Namespace: "org-x", Name: "missing-role"}}, 1)
+	cond := findCondition(rl, "Degraded")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("expected Degraded=True, got %+v", cond)
+	}
+	if cond.Reason != "UnresolvedInheritedRoles" {
+		t.Fatalf("expected reason UnresolvedInheritedRoles, got %s", cond.Reason)
+	}
+
+	r.setDegradedCondition(context.Background(), rl, nil, 2)
+	cond = findCondition(rl, "Degraded")
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected Degraded=False after resolution, got %+v", cond)
+	}
+}
+
+// enqueueRequestsForInheritedRoleChange enqueues dependents that inherit a
+// changed role (so a newly-created missing role triggers convergence) while
+// excluding the changed role itself and unrelated roles.
+func TestEnqueueRequestsForInheritedRoleChange(t *testing.T) {
+	changed := role("org-x", "entitlement-admin", nil)
+	dependent := role("org-x", "owner", nil, iamv1alpha1.ScopedRoleReference{Name: "entitlement-admin"})
+	unrelated := role("org-x", "billing", nil, iamv1alpha1.ScopedRoleReference{Name: "something-else"})
+
+	r := newRoleReconciler(t, changed, dependent, unrelated)
+
+	reqs := r.enqueueRequestsForInheritedRoleChange(context.Background(), changed)
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 enqueued dependent, got %d: %v", len(reqs), reqs)
+	}
+	if reqs[0].Name != "owner" || reqs[0].Namespace != "org-x" {
+		t.Fatalf("expected org-x/owner enqueued, got %s/%s", reqs[0].Namespace, reqs[0].Name)
+	}
+}
+
+func findCondition(role *iamv1alpha1.Role, condType string) *metav1.Condition {
+	for i := range role.Status.Conditions {
+		if role.Status.Conditions[i].Type == condType {
+			return &role.Status.Conditions[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem

Fixes the reliability issue described in **milo-os/milo#628**.

A single unresolvable `inheritedRoles` reference disabled **every** permission a Milo IAM `Role` granted. The role controller (`internal/controller/role_controller.go`) computed effective permissions **all-or-nothing**: `getAllEffectivePermissions` returned an error on the first `NotFound` inherited role, so `Reconcile`:

1. wrote **zero** OpenFGA tuples,
2. set `Ready=False` / `EffectivePermissionsError`,
3. returned the error, pushing the role into ~16 min exponential backoff.

For a broadly-inherited role like a project `owner` (~16 inherited roles), one transient or typo'd reference caused a **broad, silent access outage** across unrelated capabilities (the real incident: project owners couldn't read `LocationBinding`s because `owner` inherited a not-yet-created `entitlement-admin`). Recovery only happened minutes later on the natural backoff retry.

This is GitOps-hostile: a role legitimately arriving before the role it inherits is a normal transient under eventual consistency.

## Change

Make effective-permission computation degrade gracefully:

- **Graceful degradation, fail-closed.** `getAllEffectivePermissions` now records unresolved (`NotFound`) references and **skips** them (no permissions granted for the dangling ref) instead of failing the whole role. Genuine (non-`NotFound`) API errors still propagate. The resolvable permissions — the role's own plus all resolvable inherited — are applied to OpenFGA.
- **Loud, specific visibility.** A `Degraded=True` condition and a `Warning` event name the **exact** unresolved reference(s). `Ready` stays `False` (reason `UnresolvedInheritedRoles`) until every reference resolves, then converges to `Ready=True` / `Degraded=False`.
- **Fast convergence.** A new Role→Role watch enqueues every Role that inherits a changed Role, so a previously-missing inherited role appearing triggers immediate reconciliation. `NotFound` no longer returns an error, so there is no backoff to wait out either.

Downstream is unaffected: `PolicyBinding` builds tuples from `Status.EffectivePermissions` (no `Role.Ready` gate) and already watches Role changes, so it rewrites the complete tuple set once a degraded role converges.

## Explicitly NOT done

No admission-time existence deny — GitOps apply ordering stays order-independent. (The optional CI-lint acceptance item is left for a follow-up.)

## Acceptance criteria

- [x] A Role with one unresolvable `inheritedRoles` entry still grants permissions from all resolvable inherited roles.
- [x] The Role reports a clear `Degraded` / non-`Ready` condition + event naming the unresolved reference.
- [x] When the missing inherited role is created, the Role converges to fully-`Ready` without a long delay (Role→Role watch + no error/backoff).
- [x] No admission-time deny introduced.
- [ ] (Optional) CI lint across role bundles — follow-up.

## Testing

New unit tests in `role_controller_degradation_test.go` (fake client, no envtest): graceful degradation, full resolution, dedupe, degraded condition lifecycle, and dependent enqueue on inherited-role change. `go build ./...` and `go vet ./internal/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)