### PR TITLE
fix: Reduce PolicyBinding workqueue backlog

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -289,10 +289,10 @@ func runManager(
 	if err = (&controller.PolicyBindingReconciler{
 		Client:                  localMgr.GetClient(),
 		Scheme:                  localMgr.GetScheme(),
-		FgaClient:                 fgaClient,
-		StoreID:                   openfgaStoreID,
-		EventRecorder:             localMgr.GetEventRecorderFor("policybinding-controller"),
-		MaxConcurrentReconciles:   policyBindingMaxConcurrentReconciles,
+		FgaClient:               fgaClient,
+		StoreID:                 openfgaStoreID,
+		EventRecorder:           localMgr.GetEventRecorderFor("policybinding-controller"),
+		MaxConcurrentReconciles: policyBindingMaxConcurrentReconciles,
 	}).SetupWithManager(localMgr); err != nil {
 		return fmt.Errorf("unable to create controller PolicyBinding: %w", err)
 	}

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -59,6 +59,7 @@ func createManagerCommand() *cobra.Command {
 	var serverConfigFile string
 	var upstreamClusterKubeconfig string
 	var coreControlPlaneKubeconfig string
+	var policyBindingMaxConcurrentReconciles int
 
 	cmd := &cobra.Command{
 		Use:   "manager",
@@ -83,6 +84,7 @@ func createManagerCommand() *cobra.Command {
 				serverConfigFile,
 				upstreamClusterKubeconfig,
 				coreControlPlaneKubeconfig,
+				policyBindingMaxConcurrentReconciles,
 			)
 		},
 	}
@@ -112,6 +114,8 @@ func createManagerCommand() *cobra.Command {
 	cmd.Flags().StringVar(&serverConfigFile, "server-config", "", "path to the server config file")
 	cmd.Flags().StringVar(&upstreamClusterKubeconfig, "upstream-kubeconfig", "", "Path to the kubeconfig file for the upstream cluster")
 	cmd.Flags().StringVar(&coreControlPlaneKubeconfig, "core-control-plane-kubeconfig", "", "Path to the kubeconfig file for the core control plane cluster")
+	cmd.Flags().IntVar(&policyBindingMaxConcurrentReconciles, "policybinding-max-concurrent-reconciles", 8,
+		"Maximum number of concurrent PolicyBinding reconciles.")
 
 	// Mark required flags
 	if err := cmd.MarkFlagRequired("openfga-api-url"); err != nil {
@@ -143,6 +147,7 @@ func runManager(
 	serverConfigFile string,
 	upstreamClusterKubeconfig string,
 	coreControlPlaneKubeconfig string,
+	policyBindingMaxConcurrentReconciles int,
 ) error {
 	opts := zap.Options{
 		Development: true,
@@ -282,11 +287,12 @@ func runManager(
 	}
 
 	if err = (&controller.PolicyBindingReconciler{
-		Client:        localMgr.GetClient(),
-		Scheme:        localMgr.GetScheme(),
-		FgaClient:     fgaClient,
-		StoreID:       openfgaStoreID,
-		EventRecorder: localMgr.GetEventRecorderFor("policybinding-controller"),
+		Client:                  localMgr.GetClient(),
+		Scheme:                  localMgr.GetScheme(),
+		FgaClient:                 fgaClient,
+		StoreID:                   openfgaStoreID,
+		EventRecorder:             localMgr.GetEventRecorderFor("policybinding-controller"),
+		MaxConcurrentReconciles:   policyBindingMaxConcurrentReconciles,
 	}).SetupWithManager(localMgr); err != nil {
 		return fmt.Errorf("unable to create controller PolicyBinding: %w", err)
 	}

--- a/config/base/services/controller-manager/manager.yaml
+++ b/config/base/services/controller-manager/manager.yaml
@@ -46,6 +46,7 @@ spec:
           - --configmap-namespace=$(CONFIGMAP_NAMESPACE)
           - --server-config=$(OPENFGA_CONTROLLER_MANAGER_CONFIG_PATH)
           - --core-control-plane-kubeconfig=$(CORE_CONTROL_PLANE_KUBECONFIG_PATH)
+          - --policybinding-max-concurrent-reconciles=8
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -87,6 +87,9 @@ type PolicyBindingReconciler struct {
 	StoreID       string
 	Finalizers    finalizer.Finalizers
 	EventRecorder record.EventRecorder
+	// MaxConcurrentReconciles controls PolicyBinding reconcile parallelism.
+	// When zero, defaultPolicyBindingMaxConcurrentReconciles is used.
+	MaxConcurrentReconciles int
 }
 
 // Reconcile is the core reconciliation loop for PolicyBinding resources. It is called by the controller-runtime when a
@@ -746,7 +749,7 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForRoleChange(ctx context
 		"roleNamespace", changedRole.Namespace)
 
 	policyBindings := &iamdatumapiscomv1alpha1.PolicyBindingList{}
-	roleKey := openfga.RoleRefIndexKey(iamdatumapiscomv1alpha1.RoleReference{
+	roleKey := openfga.RoleRefIndexKey(changedRole.Namespace, iamdatumapiscomv1alpha1.RoleReference{
 		Name:      changedRole.Name,
 		Namespace: changedRole.Namespace,
 	})
@@ -815,8 +818,15 @@ func (r *PolicyBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	)
 
 	return controllerBuilder.WithOptions(controller.Options{
-		MaxConcurrentReconciles: defaultPolicyBindingMaxConcurrentReconciles,
+		MaxConcurrentReconciles: r.policyBindingMaxConcurrentReconciles(),
 	}).Complete(r)
+}
+
+func (r *PolicyBindingReconciler) policyBindingMaxConcurrentReconciles() int {
+	if r.MaxConcurrentReconciles > 0 {
+		return r.MaxConcurrentReconciles
+	}
+	return defaultPolicyBindingMaxConcurrentReconciles
 }
 
 func (r *PolicyBindingReconciler) setupPolicyBindingIndexes(mgr ctrl.Manager) error {
@@ -853,7 +863,7 @@ func (r *PolicyBindingReconciler) setupPolicyBindingIndexes(mgr ctrl.Manager) er
 		if !ok {
 			return nil
 		}
-		return []string{openfga.RoleRefIndexKey(policyBinding.Spec.RoleRef)}
+		return []string{openfga.RoleRefIndexKey(policyBinding.Namespace, policyBinding.Spec.RoleRef)}
 	}); err != nil {
 		return fmt.Errorf("index PolicyBinding roleRef: %w", err)
 	}

--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,6 +32,9 @@ import (
 
 const (
 	policyBindingFinalizerKey = "iam.miloapis.com/policybinding"
+	// defaultPolicyBindingMaxConcurrentReconciles allows the controller to drain
+	// the workqueue faster on clusters with many PolicyBindings.
+	defaultPolicyBindingMaxConcurrentReconciles = 8
 	// ConditionTypeSubjectValid represents the condition type for validating the subjects (users or groups) referenced in
 	// a PolicyBinding. This condition is True if all subjects are found, recognized by the API server, and have valid
 	// UIDs.
@@ -703,43 +707,24 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForProtectedResourceChang
 		"kindDefined", protectedResource.Spec.Kind)
 
 	policyBindings := &iamdatumapiscomv1alpha1.PolicyBindingList{}
-	errs := r.List(context.Background(), policyBindings) // List all policy bindings in the cluster.
-	if errs != nil {
-		log.Error(errs, "failed to list PolicyBindings for ProtectedResource change")
+	targetKindKey := fmt.Sprintf("%s/%s", protectedResource.Spec.ServiceRef.Name, protectedResource.Spec.Kind)
+	if err := r.List(ctx, policyBindings, client.MatchingFields{
+		openfga.TargetKindIndexField: targetKindKey,
+	}); err != nil {
+		log.Error(err, "failed to list PolicyBindings for ProtectedResource change")
 		return []reconcile.Request{}
 	}
 
-	requests := make([]reconcile.Request, 0)
+	requests := make([]reconcile.Request, 0, len(policyBindings.Items))
 	for _, pb := range policyBindings.Items {
-		var shouldEnqueue bool
-		var targetAPIGroup, targetKind string
-
-		// Extract APIGroup and Kind based on ResourceSelector type
-		if pb.Spec.ResourceSelector.ResourceRef != nil {
-			targetAPIGroup = pb.Spec.ResourceSelector.ResourceRef.APIGroup
-			targetKind = pb.Spec.ResourceSelector.ResourceRef.Kind
-		} else if pb.Spec.ResourceSelector.ResourceKind != nil {
-			targetAPIGroup = pb.Spec.ResourceSelector.ResourceKind.APIGroup
-			targetKind = pb.Spec.ResourceSelector.ResourceKind.Kind
-		}
-
-		// A PolicyBinding should be re-evaluated if its target APIGroup and Kind match the ServiceRef.Name and Kind of
-		// the changed ProtectedResource.
-		if targetAPIGroup == protectedResource.Spec.ServiceRef.Name &&
-			targetKind == protectedResource.Spec.Kind {
-			shouldEnqueue = true
-		}
-
-		if shouldEnqueue {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      pb.Name,
-					Namespace: pb.Namespace,
-				},
-			})
-			log.V(1).Info("Enqueuing PolicyBinding due to relevant ProtectedResource change",
-				"policyBindingName", pb.Name, "policyBindingNamespace", pb.Namespace)
-		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      pb.Name,
+				Namespace: pb.Namespace,
+			},
+		})
+		log.V(1).Info("Enqueuing PolicyBinding due to relevant ProtectedResource change",
+			"policyBindingName", pb.Name, "policyBindingNamespace", pb.Namespace)
 	}
 
 	return requests
@@ -761,26 +746,28 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForRoleChange(ctx context
 		"roleNamespace", changedRole.Namespace)
 
 	policyBindings := &iamdatumapiscomv1alpha1.PolicyBindingList{}
-	if err := r.List(ctx, policyBindings); err != nil {
+	roleKey := openfga.RoleRefIndexKey(iamdatumapiscomv1alpha1.RoleReference{
+		Name:      changedRole.Name,
+		Namespace: changedRole.Namespace,
+	})
+	if err := r.List(ctx, policyBindings, client.MatchingFields{
+		openfga.RoleRefIndexField: roleKey,
+	}); err != nil {
 		log.Error(err, "failed to list PolicyBindings for Role change", "roleName", changedRole.Name, "roleNamespace", changedRole.Namespace)
 		return []reconcile.Request{}
 	}
 
-	requests := make([]reconcile.Request, 0)
+	requests := make([]reconcile.Request, 0, len(policyBindings.Items))
 	for _, pb := range policyBindings.Items {
-		// A PolicyBinding should be re-evaluated if its RoleRef matches the changed Role. The RoleRef in PolicyBindingSpec
-		// contains Name and Namespace. An empty RoleRef.Namespace typically refers to a cluster-scoped Role.
-		if pb.Spec.RoleRef.Name == changedRole.Name && pb.Spec.RoleRef.Namespace == changedRole.Namespace {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      pb.Name,
-					Namespace: pb.Namespace, // This is the PolicyBinding's namespace
-				},
-			})
-			log.V(1).Info("Enqueuing PolicyBinding due to relevant Role change",
-				"policyBindingName", pb.Name, "policyBindingNamespace", pb.Namespace,
-				"changedRoleName", changedRole.Name, "changedRoleNamespace", changedRole.Namespace)
-		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      pb.Name,
+				Namespace: pb.Namespace,
+			},
+		})
+		log.V(1).Info("Enqueuing PolicyBinding due to relevant Role change",
+			"policyBindingName", pb.Name, "policyBindingNamespace", pb.Namespace,
+			"changedRoleName", changedRole.Name, "changedRoleNamespace", changedRole.Namespace)
 	}
 	return requests
 }
@@ -790,6 +777,10 @@ func (r *PolicyBindingReconciler) enqueuePolicyBindingsForRoleChange(ctx context
 func (r *PolicyBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.RESTMapper == nil {
 		r.RESTMapper = mgr.GetRESTMapper()
+	}
+
+	if err := r.setupPolicyBindingIndexes(mgr); err != nil {
+		return err
 	}
 
 	// Initialize finalizers
@@ -823,5 +814,49 @@ func (r *PolicyBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		handler.EnqueueRequestsFromMapFunc(r.enqueuePolicyBindingsForRoleChange),
 	)
 
-	return controllerBuilder.Complete(r)
+	return controllerBuilder.WithOptions(controller.Options{
+		MaxConcurrentReconciles: defaultPolicyBindingMaxConcurrentReconciles,
+	}).Complete(r)
+}
+
+func (r *PolicyBindingReconciler) setupPolicyBindingIndexes(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &iamdatumapiscomv1alpha1.PolicyBinding{}, openfga.TargetObjectIndexField, func(rawObj client.Object) []string {
+		policyBinding, ok := rawObj.(*iamdatumapiscomv1alpha1.PolicyBinding)
+		if !ok {
+			return nil
+		}
+		key, err := openfga.TargetObjectFromResourceSelector(policyBinding.Spec.ResourceSelector)
+		if err != nil {
+			return nil
+		}
+		return []string{key}
+	}); err != nil {
+		return fmt.Errorf("index PolicyBinding target object: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &iamdatumapiscomv1alpha1.PolicyBinding{}, openfga.TargetKindIndexField, func(rawObj client.Object) []string {
+		policyBinding, ok := rawObj.(*iamdatumapiscomv1alpha1.PolicyBinding)
+		if !ok {
+			return nil
+		}
+		key, err := openfga.TargetKindFromResourceSelector(policyBinding.Spec.ResourceSelector)
+		if err != nil {
+			return nil
+		}
+		return []string{key}
+	}); err != nil {
+		return fmt.Errorf("index PolicyBinding target kind: %w", err)
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &iamdatumapiscomv1alpha1.PolicyBinding{}, openfga.RoleRefIndexField, func(rawObj client.Object) []string {
+		policyBinding, ok := rawObj.(*iamdatumapiscomv1alpha1.PolicyBinding)
+		if !ok {
+			return nil
+		}
+		return []string{openfga.RoleRefIndexKey(policyBinding.Spec.RoleRef)}
+	}); err != nil {
+		return fmt.Errorf("index PolicyBinding roleRef: %w", err)
+	}
+
+	return nil
 }

--- a/internal/openfga/index.go
+++ b/internal/openfga/index.go
@@ -18,7 +18,11 @@ const (
 // TargetObjectFromResourceSelector returns the OpenFGA target object identifier for a selector.
 func TargetObjectFromResourceSelector(selector iamdatumapiscomv1alpha1.ResourceSelector) (string, error) {
 	if selector.ResourceRef != nil {
-		return fmt.Sprintf("%s/%s:%s", selector.ResourceRef.APIGroup, selector.ResourceRef.Kind, selector.ResourceRef.Name), nil
+		ref := selector.ResourceRef
+		if ref.Namespace != "" {
+			return fmt.Sprintf("%s/%s:%s/%s", ref.APIGroup, ref.Kind, ref.Namespace, ref.Name), nil
+		}
+		return fmt.Sprintf("%s/%s:%s", ref.APIGroup, ref.Kind, ref.Name), nil
 	}
 
 	if selector.ResourceKind != nil {
@@ -42,6 +46,11 @@ func TargetKindFromResourceSelector(selector iamdatumapiscomv1alpha1.ResourceSel
 }
 
 // RoleRefIndexKey returns the index key for a PolicyBinding roleRef.
-func RoleRefIndexKey(roleRef iamdatumapiscomv1alpha1.RoleReference) string {
-	return roleRef.Namespace + "/" + roleRef.Name
+// When roleRef.Namespace is empty it defaults to the PolicyBinding namespace.
+func RoleRefIndexKey(policyBindingNamespace string, roleRef iamdatumapiscomv1alpha1.RoleReference) string {
+	namespace := roleRef.Namespace
+	if namespace == "" {
+		namespace = policyBindingNamespace
+	}
+	return namespace + "/" + roleRef.Name
 }

--- a/internal/openfga/index.go
+++ b/internal/openfga/index.go
@@ -1,0 +1,47 @@
+package openfga
+
+import (
+	"fmt"
+
+	iamdatumapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+)
+
+const (
+	// TargetObjectIndexField indexes PolicyBindings by their OpenFGA target object key.
+	TargetObjectIndexField = "openfga.targetObject"
+	// TargetKindIndexField indexes PolicyBindings by APIGroup/Kind target selector.
+	TargetKindIndexField = "openfga.targetKind"
+	// RoleRefIndexField indexes PolicyBindings by roleRef namespace/name.
+	RoleRefIndexField = "openfga.roleRef"
+)
+
+// TargetObjectFromResourceSelector returns the OpenFGA target object identifier for a selector.
+func TargetObjectFromResourceSelector(selector iamdatumapiscomv1alpha1.ResourceSelector) (string, error) {
+	if selector.ResourceRef != nil {
+		return fmt.Sprintf("%s/%s:%s", selector.ResourceRef.APIGroup, selector.ResourceRef.Kind, selector.ResourceRef.Name), nil
+	}
+
+	if selector.ResourceKind != nil {
+		return fmt.Sprintf("%s:%s/%s", TypeRoot, selector.ResourceKind.APIGroup, selector.ResourceKind.Kind), nil
+	}
+
+	return "", fmt.Errorf("resourceSelector must specify either resourceRef or resourceKind")
+}
+
+// TargetKindFromResourceSelector returns the APIGroup/Kind key for a PolicyBinding selector.
+func TargetKindFromResourceSelector(selector iamdatumapiscomv1alpha1.ResourceSelector) (string, error) {
+	if selector.ResourceRef != nil {
+		return fmt.Sprintf("%s/%s", selector.ResourceRef.APIGroup, selector.ResourceRef.Kind), nil
+	}
+
+	if selector.ResourceKind != nil {
+		return fmt.Sprintf("%s/%s", selector.ResourceKind.APIGroup, selector.ResourceKind.Kind), nil
+	}
+
+	return "", fmt.Errorf("resourceSelector must specify either resourceRef or resourceKind")
+}
+
+// RoleRefIndexKey returns the index key for a PolicyBinding roleRef.
+func RoleRefIndexKey(roleRef iamdatumapiscomv1alpha1.RoleReference) string {
+	return roleRef.Namespace + "/" + roleRef.Name
+}

--- a/internal/openfga/index_test.go
+++ b/internal/openfga/index_test.go
@@ -22,6 +22,23 @@ func TestTargetObjectFromResourceSelector(t *testing.T) {
 	}
 }
 
+func TestTargetObjectFromResourceSelectorWithNamespace(t *testing.T) {
+	key, err := TargetObjectFromResourceSelector(iamdatumapiscomv1alpha1.ResourceSelector{
+		ResourceRef: &iamdatumapiscomv1alpha1.ResourceReference{
+			APIGroup:  "resourcemanager.miloapis.com",
+			Kind:      "Project",
+			Name:      "proj-abc",
+			Namespace: "org-ns",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "resourcemanager.miloapis.com/Project:org-ns/proj-abc" {
+		t.Fatalf("got %q", key)
+	}
+}
+
 func TestTargetKindFromResourceSelector(t *testing.T) {
 	key, err := TargetKindFromResourceSelector(iamdatumapiscomv1alpha1.ResourceSelector{
 		ResourceRef: &iamdatumapiscomv1alpha1.ResourceReference{
@@ -39,11 +56,20 @@ func TestTargetKindFromResourceSelector(t *testing.T) {
 }
 
 func TestRoleRefIndexKey(t *testing.T) {
-	key := RoleRefIndexKey(iamdatumapiscomv1alpha1.RoleReference{
+	key := RoleRefIndexKey("datum-cloud", iamdatumapiscomv1alpha1.RoleReference{
 		Name:      "owner",
 		Namespace: "datum-cloud",
 	})
 	if key != "datum-cloud/owner" {
+		t.Fatalf("got %q", key)
+	}
+}
+
+func TestRoleRefIndexKeyDefaultsToPolicyBindingNamespace(t *testing.T) {
+	key := RoleRefIndexKey("org-abc", iamdatumapiscomv1alpha1.RoleReference{
+		Name: "owner",
+	})
+	if key != "org-abc/owner" {
 		t.Fatalf("got %q", key)
 	}
 }

--- a/internal/openfga/index_test.go
+++ b/internal/openfga/index_test.go
@@ -1,0 +1,49 @@
+package openfga
+
+import (
+	"testing"
+
+	iamdatumapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+)
+
+func TestTargetObjectFromResourceSelector(t *testing.T) {
+	key, err := TargetObjectFromResourceSelector(iamdatumapiscomv1alpha1.ResourceSelector{
+		ResourceRef: &iamdatumapiscomv1alpha1.ResourceReference{
+			APIGroup: "resourcemanager.miloapis.com",
+			Kind:     "Organization",
+			Name:     "org-abc",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "resourcemanager.miloapis.com/Organization:org-abc" {
+		t.Fatalf("got %q", key)
+	}
+}
+
+func TestTargetKindFromResourceSelector(t *testing.T) {
+	key, err := TargetKindFromResourceSelector(iamdatumapiscomv1alpha1.ResourceSelector{
+		ResourceRef: &iamdatumapiscomv1alpha1.ResourceReference{
+			APIGroup: "resourcemanager.miloapis.com",
+			Kind:     "Organization",
+			Name:     "org-abc",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "resourcemanager.miloapis.com/Organization" {
+		t.Fatalf("got %q", key)
+	}
+}
+
+func TestRoleRefIndexKey(t *testing.T) {
+	key := RoleRefIndexKey(iamdatumapiscomv1alpha1.RoleReference{
+		Name:      "owner",
+		Namespace: "datum-cloud",
+	})
+	if key != "datum-cloud/owner" {
+		t.Fatalf("got %q", key)
+	}
+}

--- a/internal/openfga/policy_reconciler.go
+++ b/internal/openfga/policy_reconciler.go
@@ -190,9 +190,11 @@ func (r *PolicyReconciler) siblingDesiredTuples(
 	targetObject string,
 	validPerms map[string]struct{},
 ) ([]*openfgav1.TupleKey, error) {
-	var allBindings iamdatumapiscomv1alpha1.PolicyBindingList
-	if err := r.K8sClient.List(ctx, &allBindings); err != nil {
-		return nil, fmt.Errorf("failed to list PolicyBindings: %w", err)
+	var siblingBindings iamdatumapiscomv1alpha1.PolicyBindingList
+	if err := r.K8sClient.List(ctx, &siblingBindings, client.MatchingFields{
+		TargetObjectIndexField: targetObject,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list sibling PolicyBindings: %w", err)
 	}
 
 	triggerSubjects := make(map[string]struct{})
@@ -201,17 +203,11 @@ func (r *PolicyReconciler) siblingDesiredTuples(
 	}
 
 	var desired []*openfgav1.TupleKey
-	for i := range allBindings.Items {
-		other := allBindings.Items[i]
+	for i := range siblingBindings.Items {
+		other := siblingBindings.Items[i]
 
 		// Skip the binding itself.
 		if other.Namespace == binding.Namespace && other.Name == binding.Name {
-			continue
-		}
-
-		// Must target the same resource object.
-		otherTarget, err := r.getTargetObjectFromResourceSelector(other.Spec.ResourceSelector)
-		if err != nil || otherTarget != targetObject {
 			continue
 		}
 
@@ -407,19 +403,7 @@ func (r *PolicyReconciler) getExistingTuples(
 
 // getTargetObjectFromResourceSelector extracts the target object identifier from ResourceSelector
 func (r *PolicyReconciler) getTargetObjectFromResourceSelector(selector iamdatumapiscomv1alpha1.ResourceSelector) (string, error) {
-	if selector.ResourceRef != nil {
-		// For specific resource instances: apiGroup/Kind:name
-		return fmt.Sprintf("%s/%s:%s", selector.ResourceRef.APIGroup, selector.ResourceRef.Kind, selector.ResourceRef.Name), nil
-	}
-
-	if selector.ResourceKind != nil {
-		// For all instances of a resource kind the permission model
-		// targets the kind-level root object in the same format as a specific
-		// instance but using the TypeRoot prefix.
-		return fmt.Sprintf("%s:%s/%s", TypeRoot, selector.ResourceKind.APIGroup, selector.ResourceKind.Kind), nil
-	}
-
-	return "", fmt.Errorf("resourceSelector must specify either resourceRef or resourceKind")
+	return TargetObjectFromResourceSelector(selector)
 }
 
 func convertTuplesForDelete(tuples []*openfgav1.TupleKey) []*openfgav1.TupleKeyWithoutCondition {

--- a/test/iam/overlapping-policy-bindings/chainsaw-test.yaml
+++ b/test/iam/overlapping-policy-bindings/chainsaw-test.yaml
@@ -117,18 +117,17 @@ spec:
               metadata:
                 name: binding-a-user-a-only
               status:
-                conditions:
-                  - type: TargetValid
-                    status: "True"
+                (conditions[?type == 'TargetValid']):
+                  - status: "True"
                     reason: ValidationSuccessful
-                  - type: SubjectValid
-                    status: "True"
+                (conditions[?type == 'SubjectValid']):
+                  - status: "True"
                     reason: ValidationSuccessful
-                  - type: RoleValid
-                    status: "True"
+                (conditions[?type == 'RoleValid']):
+                  - status: "True"
                     reason: ValidationSuccessful
-                  - type: Ready
-                    status: "True"
+                (conditions[?type == 'Ready']):
+                  - status: "True"
                     reason: ReconciliationSuccessful
         - assert:
             resource:
@@ -137,18 +136,17 @@ spec:
               metadata:
                 name: binding-b-both-users
               status:
-                conditions:
-                  - type: TargetValid
-                    status: "True"
+                (conditions[?type == 'TargetValid']):
+                  - status: "True"
                     reason: ValidationSuccessful
-                  - type: SubjectValid
-                    status: "True"
+                (conditions[?type == 'SubjectValid']):
+                  - status: "True"
                     reason: ValidationSuccessful
-                  - type: RoleValid
-                    status: "True"
+                (conditions[?type == 'RoleValid']):
+                  - status: "True"
                     reason: ValidationSuccessful
-                  - type: Ready
-                    status: "True"
+                (conditions[?type == 'Ready']):
+                  - status: "True"
                     reason: ReconciliationSuccessful
 
         # Verify user-a is authorized.


### PR DESCRIPTION
## Summary

New organization onboarding was waiting 3–5 minutes for OpenFGA grants to become effective. Staging metrics showed the bottleneck was PolicyBinding controller workqueue wait time (~188s average), not OpenFGA tuple writes (~200ms per reconcile).

The controller was doing a cluster-wide PolicyBinding LIST on every reconcile (for sibling tuple deduplication) and on every ProtectedResource/Role watch event. With ~1,200 bindings and a single worker, new bindings sat in the queue for minutes before reconciliation started.

This PR adds field indexes so lookups and watch fan-out query only relevant bindings, and increases `MaxConcurrentReconciles` from 1 to 8.

Key behaviors:

- `siblingDesiredTuples()` lists bindings by target object index instead of all bindings
- ProtectedResource and Role watch handlers use target-kind and roleRef indexes
- Controller runs up to 8 reconciles in parallel

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/openfga/...`
- [ ] Deploy to staging and create a new org; verify PolicyBinding `Ready=True` within seconds rather than minutes
- [ ] Confirm `workqueue_depth{controller="policybinding"}` and `workqueue_queue_duration_seconds` improve after rollout