### PR TITLE
fix: Align PolicyBinding tuple keys with authz checks

### DIFF
--- a/internal/openfga/index.go
+++ b/internal/openfga/index.go
@@ -16,12 +16,11 @@ const (
 )
 
 // TargetObjectFromResourceSelector returns the OpenFGA target object identifier for a selector.
+// For resourceRef targets the object key is always apiGroup/Kind:name, matching buildResourceObject
+// in the auth webhook. resourceRef.namespace is used when fetching the target CR, not in the tuple key.
 func TargetObjectFromResourceSelector(selector iamdatumapiscomv1alpha1.ResourceSelector) (string, error) {
 	if selector.ResourceRef != nil {
 		ref := selector.ResourceRef
-		if ref.Namespace != "" {
-			return fmt.Sprintf("%s/%s:%s/%s", ref.APIGroup, ref.Kind, ref.Namespace, ref.Name), nil
-		}
 		return fmt.Sprintf("%s/%s:%s", ref.APIGroup, ref.Kind, ref.Name), nil
 	}
 

--- a/internal/openfga/index_test.go
+++ b/internal/openfga/index_test.go
@@ -34,7 +34,7 @@ func TestTargetObjectFromResourceSelectorWithNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if key != "resourcemanager.miloapis.com/Project:org-ns/proj-abc" {
+	if key != "resourcemanager.miloapis.com/Project:proj-abc" {
 		t.Fatalf("got %q", key)
 	}
 }

--- a/test/iam/namespaced-resource-ref/chainsaw-test.yaml
+++ b/test/iam/namespaced-resource-ref/chainsaw-test.yaml
@@ -1,0 +1,147 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: namespaced-resource-ref
+spec:
+  description: |
+    PolicyBindings on namespaced resources must write OpenFGA tuples using
+    apiGroup/Kind:name so auth webhook checks hit the same object key.
+  steps:
+    - name: setup-and-verify-authz
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: organization-ns-ref-test-org
+        - apply:
+            resource:
+              apiVersion: resourcemanager.miloapis.com/v1alpha1
+              kind: Organization
+              metadata:
+                name: ns-ref-test-org
+              spec:
+                type: Standard
+        - apply:
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: User
+              metadata:
+                name: ns-ref-test-user
+        - apply:
+            file: roles/membership-viewer.yaml
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: Role
+            name: ns-ref-membership-viewer
+            timeout: 5m
+            for:
+              condition:
+                name: Ready
+                value: "true"
+        - create:
+            resource:
+              apiVersion: resourcemanager.miloapis.com/v1alpha1
+              kind: OrganizationMembership
+              metadata:
+                name: test-member
+                namespace: organization-ns-ref-test-org
+              spec:
+                organizationRef:
+                  name: ns-ref-test-org
+                userRef:
+                  name: ns-ref-test-user
+            outputs:
+              - name: membership
+                value: (@)
+        - apply:
+            resource:
+              apiVersion: iam.miloapis.com/v1alpha1
+              kind: PolicyBinding
+              metadata:
+                name: ns-ref-membership-binding
+              spec:
+                roleRef:
+                  name: ns-ref-membership-viewer
+                  namespace: ($namespace)
+                subjects:
+                  - kind: User
+                    name: ns-ref-test-user
+                    uid: ns-ref-test-user
+                resourceSelector:
+                  resourceRef:
+                    apiGroup: resourcemanager.miloapis.com
+                    kind: OrganizationMembership
+                    name: test-member
+                    namespace: organization-ns-ref-test-org
+                    uid: ($membership.metadata.uid)
+        - wait:
+            apiVersion: iam.miloapis.com/v1alpha1
+            kind: PolicyBinding
+            name: ns-ref-membership-binding
+            timeout: 5m
+            for:
+              condition:
+                name: Ready
+                value: "true"
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: ns-ref-authz-check
+              spec:
+                restartPolicy: Never
+                containers:
+                - name: curl
+                  image: curlimages/curl:latest
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      response=$(curl -ksS https://auth-provider-openfga-authz-webhook.auth-provider-openfga-system.svc.cluster.local:8090/apis/authorization.k8s.io/v1/subjectaccessreviews \
+                        -H "Content-Type: application/json" \
+                        -d @- << EOF
+                      {
+                        "apiVersion": "authorization.k8s.io/v1",
+                        "kind": "SubjectAccessReview",
+                        "spec": {
+                          "user": "ns-ref-test-user",
+                          "uid": "ns-ref-test-user",
+                          "extra": {
+                            "resourcemanager.miloapis.com/organization-id": ["ns-ref-test-org"]
+                          },
+                          "groups": ["system:authenticated"],
+                          "resourceAttributes": {
+                            "group": "resourcemanager.miloapis.com",
+                            "resource": "organizationmemberships",
+                            "version": "v1alpha1",
+                            "verb": "get",
+                            "name": "test-member",
+                            "namespace": "organization-ns-ref-test-org"
+                          }
+                        }
+                      }
+                      EOF
+                      )
+                      echo "Webhook response: $response"
+                      if ! echo "$response" | grep -q '"kind":"SubjectAccessReview"'; then
+                        echo "FAIL: invalid response format"
+                        exit 1
+                      fi
+                      if echo "$response" | grep -q '"allowed"[[:space:]]*:[[:space:]]*true'; then
+                        echo "PASS: user authorized for namespaced membership get"
+                        exit 0
+                      else
+                        echo "FAIL: user not authorized"
+                        exit 1
+                      fi
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: ns-ref-authz-check
+            timeout: 30s
+            for:
+              jsonPath:
+                path: "status.phase"
+                value: "Succeeded"

--- a/test/iam/namespaced-resource-ref/chainsaw-test.yaml
+++ b/test/iam/namespaced-resource-ref/chainsaw-test.yaml
@@ -112,7 +112,7 @@ spec:
                         "kind": "SubjectAccessReview",
                         "spec": {
                           "user": "ns-ref-test-user",
-                          "uid": "($user.metadata.uid)",
+                          "uid": "ns-ref-test-user",
                           "extra": {
                             "resourcemanager.miloapis.com/organization-id": ["ns-ref-test-org"]
                           },

--- a/test/iam/namespaced-resource-ref/chainsaw-test.yaml
+++ b/test/iam/namespaced-resource-ref/chainsaw-test.yaml
@@ -23,12 +23,17 @@ spec:
                 name: ns-ref-test-org
               spec:
                 type: Standard
-        - apply:
+        - create:
             resource:
               apiVersion: iam.miloapis.com/v1alpha1
               kind: User
               metadata:
                 name: ns-ref-test-user
+              spec:
+                email: ns-ref-test-user@test.datum.net
+            outputs:
+              - name: user
+                value: (@)
         - apply:
             file: roles/membership-viewer.yaml
         - wait:
@@ -68,7 +73,7 @@ spec:
                 subjects:
                   - kind: User
                     name: ns-ref-test-user
-                    uid: ns-ref-test-user
+                    uid: ($user.metadata.uid)
                 resourceSelector:
                   resourceRef:
                     apiGroup: resourcemanager.miloapis.com
@@ -107,7 +112,7 @@ spec:
                         "kind": "SubjectAccessReview",
                         "spec": {
                           "user": "ns-ref-test-user",
-                          "uid": "ns-ref-test-user",
+                          "uid": "($user.metadata.uid)",
                           "extra": {
                             "resourcemanager.miloapis.com/organization-id": ["ns-ref-test-org"]
                           },

--- a/test/iam/namespaced-resource-ref/roles/membership-viewer.yaml
+++ b/test/iam/namespaced-resource-ref/roles/membership-viewer.yaml
@@ -1,0 +1,8 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: ns-ref-membership-viewer
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - resourcemanager.miloapis.com/organizationmemberships.get


### PR DESCRIPTION
## Summary

#114 started writing OpenFGA tuple keys with the resource namespace when a PolicyBinding's `resourceRef` includes one, producing keys like `resourcemanager.miloapis.com/OrganizationMembership:organization-foo/member-bar`. The auth webhook still checks `apiGroup/Kind:name` via `buildResourceObject`, so those tuples are invisible to authorization.

Cluster-scoped bindings (Organization, User, etc.) were unaffected. Namespaced targets like OrganizationMembership are the problem: the binding reconciles to Ready, tuples get written, but SAR never consults them. Grants that existed before #114 keep working, which is why this was easy to miss until review.

This PR reverts tuple labeling to `apiGroup/Kind:name`. `resourceRef.namespace` is still used when fetching the target CR for validation. Index and queue throughput changes from #114 are unchanged.

After deploy, staging will need a cleanup pass for tuples written with the namespace-qualified key format.

## Test plan

- [x] `go test ./internal/openfga/...` passes locally
- [x] Chainsaw test `test/iam/namespaced-resource-ref/` passes in CI (PolicyBinding on namespaced OrganizationMembership + SAR get check)
- [ ] Plan staging tuple audit/cleanup before or after rollout

## Notes for reviewers

Follow-up to Scott's comment on #114. This does not revert `MaxConcurrentReconciles=8` or the PolicyBinding index work.

Related to #114