### PR TITLE
fix: stop self-inflicted PolicyBinding status conflicts

### DIFF
--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -185,12 +186,11 @@ func (r *PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	// At this juncture, both ResourceSelector and all Subjects have been successfully validated. Their respective conditions
-	// (TargetValid=True, SubjectValid=True) have been set in memory by their validation functions. We need to persist
-	// these positive statuses before proceeding to the OpenFGA reconciliation, which is an external call.
-	if err := r.updatePolicyBindingStatus(ctx, policyBinding, oldStatus, currentGeneration); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update PolicyBinding status after successful validations before OpenFGA reconciliation: %w", err)
-	}
+	// Both ResourceSelector and all Subjects validated (TargetValid=True,
+	// SubjectValid=True set in memory). These positive conditions are persisted
+	// together with RoleValid and Ready in the single status write at the end of
+	// this reconcile. Failure paths (OpenFGA reconcile errors) still persist the
+	// in-memory conditions on their own.
 
 	// Reconcile with OpenFGA. This creates/updates/deletes tuples in OpenFGA based on the PolicyBinding. This step also
 	// implicitly validates the RoleRef by attempting to use the role.
@@ -502,15 +502,43 @@ func (r *PolicyBindingReconciler) updatePolicyBindingStatus(ctx context.Context,
 
 	policyBinding.Status.ObservedGeneration = observedGen
 
-	// Only update if the status has actually changed
-	if !equality.Semantic.DeepEqual(oldStatus, &policyBinding.Status) {
-		if err := r.Status().Update(ctx, policyBinding); err != nil {
-			return err
-		}
-		log.V(1).Info("PolicyBinding status updated")
-	} else {
+	// Only update if the status has actually changed.
+	if equality.Semantic.DeepEqual(oldStatus, &policyBinding.Status) {
 		log.V(1).Info("PolicyBinding status unchanged; skipping update")
+		return nil
 	}
+
+	// The reconcile loop computes the desired status against the version read at
+	// its start, but by the time we write, another actor (the finalizer update,
+	// a spec change, or a concurrent reconcile) may have bumped the object's
+	// resourceVersion, producing a conflict. Retry on conflict by re-fetching the
+	// latest object and re-applying the computed status so a stale read does not
+	// leave the binding without a Ready condition.
+	desiredStatus := policyBinding.Status.DeepCopy()
+	key := client.ObjectKeyFromObject(policyBinding)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &iamdatumapiscomv1alpha1.PolicyBinding{}
+		if getErr := r.Get(ctx, key, latest); getErr != nil {
+			return getErr
+		}
+
+		desiredStatus.DeepCopyInto(&latest.Status)
+		if updateErr := r.Status().Update(ctx, latest); updateErr != nil {
+			return updateErr
+		}
+
+		// Reflect the persisted state back onto the caller's object so later use
+		// of policyBinding (logging, requeue decisions) sees the fresh version.
+		latest.Status.DeepCopyInto(&policyBinding.Status)
+		policyBinding.ResourceVersion = latest.ResourceVersion
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.V(1).Info("PolicyBinding status updated")
 	return nil
 }
 

--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -21,13 +21,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -502,43 +504,28 @@ func (r *PolicyBindingReconciler) updatePolicyBindingStatus(ctx context.Context,
 
 	policyBinding.Status.ObservedGeneration = observedGen
 
-	// Only update if the status has actually changed.
+	// Only write if the status has actually changed.
 	if equality.Semantic.DeepEqual(oldStatus, &policyBinding.Status) {
 		log.V(1).Info("PolicyBinding status unchanged; skipping update")
 		return nil
 	}
 
-	// The reconcile loop computes the desired status against the version read at
-	// its start, but by the time we write, another actor (the finalizer update,
-	// a spec change, or a concurrent reconcile) may have bumped the object's
-	// resourceVersion, producing a conflict. Retry on conflict by re-fetching the
-	// latest object and re-applying the computed status so a stale read does not
-	// leave the binding without a Ready condition.
-	desiredStatus := policyBinding.Status.DeepCopy()
-	key := client.ObjectKeyFromObject(policyBinding)
+	// This controller is the only writer of PolicyBinding status: the API server
+	// audit log shows every status write coming from this controller, while milo
+	// only creates and deletes the object. A JSON merge patch against the status
+	// subresource therefore needs no optimistic concurrency. It carries no
+	// resourceVersion, so a lagging informer read cannot turn the write into a
+	// conflict, and there is no competing writer whose changes it could clobber.
+	// This replaces a read-modify-write Update that raced its own requeues and
+	// produced a burst of 409s on every binding during signup.
+	base := policyBinding.DeepCopy()
+	base.Status = *oldStatus
 
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &iamdatumapiscomv1alpha1.PolicyBinding{}
-		if getErr := r.Get(ctx, key, latest); getErr != nil {
-			return getErr
-		}
-
-		desiredStatus.DeepCopyInto(&latest.Status)
-		if updateErr := r.Status().Update(ctx, latest); updateErr != nil {
-			return updateErr
-		}
-
-		// Reflect the persisted state back onto the caller's object so later use
-		// of policyBinding (logging, requeue decisions) sees the fresh version.
-		latest.Status.DeepCopyInto(&policyBinding.Status)
-		policyBinding.ResourceVersion = latest.ResourceVersion
-		return nil
-	})
-	if err != nil {
+	if err := r.Status().Patch(ctx, policyBinding, client.MergeFrom(base)); err != nil {
 		return err
 	}
 
-	log.V(1).Info("PolicyBinding status updated")
+	log.V(1).Info("PolicyBinding status patched")
 	return nil
 }
 
@@ -830,7 +817,7 @@ func (r *PolicyBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		For(&iamdatumapiscomv1alpha1.PolicyBinding{}).
+		For(&iamdatumapiscomv1alpha1.PolicyBinding{}, builder.WithPredicates(policyBindingReconcilePredicate())).
 		Named("policybinding")
 
 	// Watch for changes to ProtectedResource CRs and enqueue PolicyBindings that might be affected.
@@ -855,6 +842,30 @@ func (r *PolicyBindingReconciler) policyBindingMaxConcurrentReconciles() int {
 		return r.MaxConcurrentReconciles
 	}
 	return defaultPolicyBindingMaxConcurrentReconciles
+}
+
+// policyBindingReconcilePredicate filters PolicyBinding events on the primary
+// watch so the controller reconciles on creation, deletion, spec changes, and
+// finalizer changes, but ignores updates that only touch status. This
+// controller is the sole writer of status, so waking on its own status writes
+// only re-runs the full OpenFGA tuple diff and races the next write. Dropping
+// those events removes the self-inflicted reconcile storm that the audit log
+// showed generating repeated status-update conflicts on every binding created
+// during signup.
+func policyBindingReconcilePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return true
+			}
+			// Deletion is initiated by setting deletionTimestamp, which does not
+			// bump generation; catch that transition so finalizers still run.
+			deletionChanged := (e.ObjectOld.GetDeletionTimestamp() == nil) != (e.ObjectNew.GetDeletionTimestamp() == nil)
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
+				deletionChanged ||
+				!equalFinalizers(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers())
+		},
+	}
 }
 
 func (r *PolicyBindingReconciler) setupPolicyBindingIndexes(mgr ctrl.Manager) error {

--- a/internal/controller/policybinding_status_test.go
+++ b/internal/controller/policybinding_status_test.go
@@ -2,17 +2,15 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 
 	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 func policyBinding(namespace, name string) *iamv1alpha1.PolicyBinding {
@@ -33,49 +31,47 @@ func readyPolicyBinding(namespace, name string) *iamv1alpha1.PolicyBinding {
 	return pb
 }
 
-// A single conflict on the status subresource must not drop the update: the
-// reconciler re-reads the latest object and re-applies the computed status, so
-// the binding still ends up with its Ready condition persisted.
-func TestUpdatePolicyBindingStatus_RetriesOnConflict(t *testing.T) {
+// The status write is a merge patch on the status subresource, so it persists
+// the computed conditions and observedGeneration in a single call.
+func TestUpdatePolicyBindingStatus_PatchesStatus(t *testing.T) {
 	s := degradationScheme(t)
 	stored := policyBinding("org-1", "binding-1")
 
-	var updates int32
+	var patches int32
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(stored).
 		WithStatusSubresource(&iamv1alpha1.PolicyBinding{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourceUpdate: func(
+			SubResourcePatch: func(
 				ctx context.Context,
 				cl client.Client,
 				subResourceName string,
 				obj client.Object,
-				opts ...client.SubResourceUpdateOption,
+				patch client.Patch,
+				opts ...client.SubResourcePatchOption,
 			) error {
-				if atomic.AddInt32(&updates, 1) == 1 {
-					return apierrors.NewConflict(
-						schema.GroupResource{Group: iamv1alpha1.SchemeGroupVersion.Group, Resource: "policybindings"},
-						obj.GetName(),
-						fmt.Errorf("the object has been modified"),
-					)
-				}
-				return cl.Status().Update(ctx, obj, opts...)
+				atomic.AddInt32(&patches, 1)
+				return cl.Status().Patch(ctx, obj, patch, opts...)
 			},
 		}).
 		Build()
 
 	r := &PolicyBindingReconciler{Client: c, Scheme: s}
 
-	desired := readyPolicyBinding("org-1", "binding-1")
-	oldStatus := &iamv1alpha1.PolicyBindingStatus{}
+	current := policyBinding("org-1", "binding-1")
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(stored), current); err != nil {
+		t.Fatalf("get stored binding: %v", err)
+	}
+	oldStatus := current.Status.DeepCopy()
+	current.Status = readyPolicyBinding("org-1", "binding-1").Status
 
-	if err := r.updatePolicyBindingStatus(context.Background(), desired, oldStatus, 1); err != nil {
-		t.Fatalf("expected conflict to be retried, got error: %v", err)
+	if err := r.updatePolicyBindingStatus(context.Background(), current, oldStatus, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&updates); got < 2 {
-		t.Fatalf("expected at least 2 status update attempts (1 conflict + 1 success), got %d", got)
+	if got := atomic.LoadInt32(&patches); got != 1 {
+		t.Fatalf("expected exactly 1 status patch, got %d", got)
 	}
 
 	persisted := &iamv1alpha1.PolicyBinding{}
@@ -83,10 +79,40 @@ func TestUpdatePolicyBindingStatus_RetriesOnConflict(t *testing.T) {
 		t.Fatalf("get persisted binding: %v", err)
 	}
 	if len(persisted.Status.Conditions) != 1 || persisted.Status.Conditions[0].Type != "Ready" {
-		t.Fatalf("expected Ready condition persisted after retry, got %+v", persisted.Status.Conditions)
+		t.Fatalf("expected Ready condition persisted, got %+v", persisted.Status.Conditions)
 	}
 	if persisted.Status.ObservedGeneration != 1 {
 		t.Fatalf("expected observedGeneration=1, got %d", persisted.Status.ObservedGeneration)
+	}
+}
+
+// A merge patch carries no resourceVersion, so a status write computed from a
+// stale (lagging-cache) read must still succeed rather than conflict.
+func TestUpdatePolicyBindingStatus_ConflictFreeOnStaleObject(t *testing.T) {
+	s := degradationScheme(t)
+	stored := policyBinding("org-1", "binding-1")
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(stored).
+		WithStatusSubresource(&iamv1alpha1.PolicyBinding{}).
+		Build()
+
+	r := &PolicyBindingReconciler{Client: c, Scheme: s}
+
+	current := policyBinding("org-1", "binding-1")
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(stored), current); err != nil {
+		t.Fatalf("get stored binding: %v", err)
+	}
+
+	// Simulate an informer read that is behind the API server: pin an old
+	// resourceVersion onto the in-memory object before writing status.
+	current.ResourceVersion = "1"
+	oldStatus := current.Status.DeepCopy()
+	current.Status = readyPolicyBinding("org-1", "binding-1").Status
+
+	if err := r.updatePolicyBindingStatus(context.Background(), current, oldStatus, 1); err != nil {
+		t.Fatalf("stale-read status write must not conflict, got: %v", err)
 	}
 }
 
@@ -97,21 +123,22 @@ func TestUpdatePolicyBindingStatus_SkipsWhenUnchanged(t *testing.T) {
 	stored := readyPolicyBinding("org-1", "binding-1")
 	stored.Status.ObservedGeneration = 1
 
-	var updates int32
+	var patches int32
 	c := fake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(stored).
 		WithStatusSubresource(&iamv1alpha1.PolicyBinding{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourceUpdate: func(
+			SubResourcePatch: func(
 				ctx context.Context,
 				cl client.Client,
 				subResourceName string,
 				obj client.Object,
-				opts ...client.SubResourceUpdateOption,
+				patch client.Patch,
+				opts ...client.SubResourcePatchOption,
 			) error {
-				atomic.AddInt32(&updates, 1)
-				return cl.Status().Update(ctx, obj, opts...)
+				atomic.AddInt32(&patches, 1)
+				return cl.Status().Patch(ctx, obj, patch, opts...)
 			},
 		}).
 		Build()
@@ -126,7 +153,51 @@ func TestUpdatePolicyBindingStatus_SkipsWhenUnchanged(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&updates); got != 0 {
+	if got := atomic.LoadInt32(&patches); got != 0 {
 		t.Fatalf("expected no status writes when unchanged, got %d", got)
+	}
+}
+
+// The primary-watch predicate must ignore status-only updates (the source of
+// the self-inflicted reconcile storm) while still reconciling on spec,
+// finalizer, and deletion changes.
+func TestPolicyBindingReconcilePredicate(t *testing.T) {
+	p := policyBindingReconcilePredicate()
+
+	base := func() *iamv1alpha1.PolicyBinding {
+		pb := policyBinding("org-1", "binding-1")
+		pb.Generation = 1
+		pb.Finalizers = []string{policyBindingFinalizerKey}
+		return pb
+	}
+
+	statusOnly := base()
+	statusOnly.Status.Conditions = []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}}
+	statusOnly.ResourceVersion = "2"
+	if p.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: statusOnly}) {
+		t.Fatalf("status-only update should be ignored")
+	}
+
+	specChange := base()
+	specChange.Generation = 2
+	if !p.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: specChange}) {
+		t.Fatalf("generation change should trigger reconcile")
+	}
+
+	finalizerChange := base()
+	finalizerChange.Finalizers = nil
+	if !p.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: finalizerChange}) {
+		t.Fatalf("finalizer change should trigger reconcile")
+	}
+
+	deleting := base()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	if !p.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: deleting}) {
+		t.Fatalf("deletion should trigger reconcile")
+	}
+
+	if !p.Update(event.UpdateEvent{ObjectOld: nil, ObjectNew: nil}) {
+		t.Fatalf("nil objects should default to reconcile")
 	}
 }

--- a/internal/controller/policybinding_status_test.go
+++ b/internal/controller/policybinding_status_test.go
@@ -1,0 +1,132 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func policyBinding(namespace, name string) *iamv1alpha1.PolicyBinding {
+	return &iamv1alpha1.PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}
+}
+
+func readyPolicyBinding(namespace, name string) *iamv1alpha1.PolicyBinding {
+	pb := policyBinding(namespace, name)
+	pb.Status.Conditions = []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "ReconciliationSuccessful",
+		Message:            "PolicyBinding reconciled successfully.",
+		LastTransitionTime: metav1.Now(),
+	}}
+	return pb
+}
+
+// A single conflict on the status subresource must not drop the update: the
+// reconciler re-reads the latest object and re-applies the computed status, so
+// the binding still ends up with its Ready condition persisted.
+func TestUpdatePolicyBindingStatus_RetriesOnConflict(t *testing.T) {
+	s := degradationScheme(t)
+	stored := policyBinding("org-1", "binding-1")
+
+	var updates int32
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(stored).
+		WithStatusSubresource(&iamv1alpha1.PolicyBinding{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(
+				ctx context.Context,
+				cl client.Client,
+				subResourceName string,
+				obj client.Object,
+				opts ...client.SubResourceUpdateOption,
+			) error {
+				if atomic.AddInt32(&updates, 1) == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: iamv1alpha1.SchemeGroupVersion.Group, Resource: "policybindings"},
+						obj.GetName(),
+						fmt.Errorf("the object has been modified"),
+					)
+				}
+				return cl.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &PolicyBindingReconciler{Client: c, Scheme: s}
+
+	desired := readyPolicyBinding("org-1", "binding-1")
+	oldStatus := &iamv1alpha1.PolicyBindingStatus{}
+
+	if err := r.updatePolicyBindingStatus(context.Background(), desired, oldStatus, 1); err != nil {
+		t.Fatalf("expected conflict to be retried, got error: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&updates); got < 2 {
+		t.Fatalf("expected at least 2 status update attempts (1 conflict + 1 success), got %d", got)
+	}
+
+	persisted := &iamv1alpha1.PolicyBinding{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(stored), persisted); err != nil {
+		t.Fatalf("get persisted binding: %v", err)
+	}
+	if len(persisted.Status.Conditions) != 1 || persisted.Status.Conditions[0].Type != "Ready" {
+		t.Fatalf("expected Ready condition persisted after retry, got %+v", persisted.Status.Conditions)
+	}
+	if persisted.Status.ObservedGeneration != 1 {
+		t.Fatalf("expected observedGeneration=1, got %d", persisted.Status.ObservedGeneration)
+	}
+}
+
+// When the status has not changed the reconciler must not issue a write at all,
+// avoiding needless API traffic and resourceVersion churn.
+func TestUpdatePolicyBindingStatus_SkipsWhenUnchanged(t *testing.T) {
+	s := degradationScheme(t)
+	stored := readyPolicyBinding("org-1", "binding-1")
+	stored.Status.ObservedGeneration = 1
+
+	var updates int32
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(stored).
+		WithStatusSubresource(&iamv1alpha1.PolicyBinding{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(
+				ctx context.Context,
+				cl client.Client,
+				subResourceName string,
+				obj client.Object,
+				opts ...client.SubResourceUpdateOption,
+			) error {
+				atomic.AddInt32(&updates, 1)
+				return cl.Status().Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &PolicyBindingReconciler{Client: c, Scheme: s}
+
+	current := readyPolicyBinding("org-1", "binding-1")
+	current.Status.ObservedGeneration = 1
+	oldStatus := current.Status.DeepCopy()
+
+	if err := r.updatePolicyBindingStatus(context.Background(), current, oldStatus, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&updates); got != 0 {
+		t.Fatalf("expected no status writes when unchanged, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

PolicyBindings were taking a burst of status-update conflicts during signup, and the first version of this PR simply retried them. That masked the problem instead of fixing it, so this reworks the change around what the API server audit log actually shows.

Pulling the audit trail for a real org-owner binding created during signup makes the cause clear. Two things stand out. First, the `status` subresource of a PolicyBinding is written by exactly one actor, this controller; `milo` only ever creates and deletes the object and never touches status. There is no external writer racing us. Second, the conflicts all happen *after* status has already converged: the controller reconciles again off its own watch events (the create, the finalizer add, its own status writes), reads a lagging informer cache, and re-issues a status `Update` against a stale `resourceVersion`, producing a 409. The storm only ends when the cache catches up and the status comparison short-circuits. Every one of these writes is the controller fighting itself.

Because the conflicts are self-inflicted rather than real contention, the fix is structural. The controller now ignores its own status-only updates on the primary watch, so it stops waking up to re-run the full OpenFGA tuple diff and collide with the next write. The remaining status write is a JSON merge patch on the status subresource, which needs no optimistic concurrency: it carries no `resourceVersion`, so a stale read can no longer turn the write into a conflict, and since status has a single writer there is nothing to clobber. The `RetryOnConflict` wrapper is gone.

## Evidence

Audit log (`audit.audit_logs`, staging) over three days on `policybindings`:

| verb | subresource | code | count |
| --- | --- | --- | --- |
| update | status | 200 | 592 |
| update | status | **409** | **197** |
| create | – | 409 | 147 |
| update | – | 409 | 11 |

Roughly a quarter of all status writes were conflicting. Full ordered timeline for one org-owner binding created during signup, with the actor for each write:

```
45.015  create         201  milo                    (creates the binding)
45.025  update         200  auth-provider-openfga   (adds finalizer)
45.061  update status  200  auth-provider-openfga   (status write, pre-OpenFGA)
45.701  update status  200  auth-provider-openfga   (status write after ~640ms of tuple work)
45.747  update status  409  auth-provider-openfga
45.789  update status  409  auth-provider-openfga
45.837  update status  409  auth-provider-openfga
45.898  update status  409  auth-provider-openfga
45.992  update status  409  auth-provider-openfga
46.111  update status  409  auth-provider-openfga
46.313  update status  409  auth-provider-openfga
46.672  update status  409  auth-provider-openfga   (8 conflicts in ~0.9s)
```

The status subresource is only ever written by `auth-provider-openfga`, and the 409 storm is that controller racing its own reconciles through a lagging cache.

## Changes

- Add a primary-watch predicate that reconciles on create, delete, spec (generation), finalizer, and deletion-timestamp changes, and drops status-only updates.
- Replace the read-modify-write status `Update` (and its `RetryOnConflict` retry loop) with a `Status().Patch` merge patch, keeping the single write per reconcile and the unchanged-status short circuit.

## Test plan

- [x] `go build ./...` and `go vet ./internal/controller/...`
- [x] `go test ./internal/controller/...` (full package, envtest)
- [x] New unit tests: merge-patch write persists conditions and observedGeneration; write is conflict-free from a stale-resourceVersion read; unchanged status issues no write; predicate ignores status-only updates but reconciles on spec, finalizer, and deletion changes.
- [ ] Deploy to staging and confirm `update status` 409s on `policybindings` drop to ~0 over a signup window in the audit log.
