### PR TITLE
fix & optimize: address OpenFGA client delays, status conflicts, and queue flooding

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
@@ -60,6 +61,9 @@ func createManagerCommand() *cobra.Command {
 	var upstreamClusterKubeconfig string
 	var coreControlPlaneKubeconfig string
 	var policyBindingMaxConcurrentReconciles int
+	var openfgaTimeout time.Duration
+	var openfgaKeepaliveTime time.Duration
+	var openfgaKeepaliveTimeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "manager",
@@ -85,6 +89,9 @@ func createManagerCommand() *cobra.Command {
 				upstreamClusterKubeconfig,
 				coreControlPlaneKubeconfig,
 				policyBindingMaxConcurrentReconciles,
+				openfgaTimeout,
+				openfgaKeepaliveTime,
+				openfgaKeepaliveTimeout,
 			)
 		},
 	}
@@ -116,6 +123,12 @@ func createManagerCommand() *cobra.Command {
 	cmd.Flags().StringVar(&coreControlPlaneKubeconfig, "core-control-plane-kubeconfig", "", "Path to the kubeconfig file for the core control plane cluster")
 	cmd.Flags().IntVar(&policyBindingMaxConcurrentReconciles, "policybinding-max-concurrent-reconciles", 8,
 		"Maximum number of concurrent PolicyBinding reconciles.")
+	cmd.Flags().DurationVar(&openfgaTimeout, "openfga-timeout", 15*time.Second,
+		"The timeout duration for OpenFGA API calls.")
+	cmd.Flags().DurationVar(&openfgaKeepaliveTime, "openfga-keepalive-time", 30*time.Second,
+		"The interval duration between keepalive pings to the OpenFGA server.")
+	cmd.Flags().DurationVar(&openfgaKeepaliveTimeout, "openfga-keepalive-timeout", 10*time.Second,
+		"The timeout duration to wait for a keepalive ping response from the OpenFGA server.")
 
 	// Mark required flags
 	if err := cmd.MarkFlagRequired("openfga-api-url"); err != nil {
@@ -148,6 +161,9 @@ func runManager(
 	upstreamClusterKubeconfig string,
 	coreControlPlaneKubeconfig string,
 	policyBindingMaxConcurrentReconciles int,
+	openfgaTimeout time.Duration,
+	openfgaKeepaliveTime time.Duration,
+	openfgaKeepaliveTimeout time.Duration,
 ) error {
 	opts := zap.Options{
 		Development: true,
@@ -208,6 +224,12 @@ func runManager(
 
 	conn, err := grpc.NewClient(openfgaAPIURL,
 		grpc.WithTransportCredentials(creds),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                openfgaKeepaliveTime,
+			Timeout:             openfgaKeepaliveTimeout,
+			PermitWithoutStream: true,
+		}),
+		grpc.WithUnaryInterceptor(timeoutUnaryInterceptor(openfgaTimeout)),
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create gRPC connection to OpenFGA: %w", err)
@@ -503,4 +525,22 @@ func ignoreCanceled(err error) error {
 		return nil
 	}
 	return err
+}
+
+func timeoutUnaryInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if _, ok := ctx.Deadline(); !ok {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
 }

--- a/config/base/services/controller-manager/manager.yaml
+++ b/config/base/services/controller-manager/manager.yaml
@@ -47,6 +47,9 @@ spec:
           - --server-config=$(OPENFGA_CONTROLLER_MANAGER_CONFIG_PATH)
           - --core-control-plane-kubeconfig=$(CORE_CONTROL_PLANE_KUBECONFIG_PATH)
           - --policybinding-max-concurrent-reconciles=8
+          - --openfga-timeout=$(OPENFGA_TIMEOUT)
+          - --openfga-keepalive-time=$(OPENFGA_KEEPALIVE_TIME)
+          - --openfga-keepalive-timeout=$(OPENFGA_KEEPALIVE_TIMEOUT)
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -78,6 +81,12 @@ spec:
           value: ""
         - name: CORE_CONTROL_PLANE_KUBECONFIG_PATH
           value: ""
+        - name: OPENFGA_TIMEOUT
+          value: "15s"
+        - name: OPENFGA_KEEPALIVE_TIME
+          value: "30s"
+        - name: OPENFGA_KEEPALIVE_TIMEOUT
+          value: "10s"
         ports:
           - containerPort: 8080
             name: metrics

--- a/internal/controller/groupmembership_controller.go
+++ b/internal/controller/groupmembership_controller.go
@@ -15,10 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
@@ -391,11 +393,13 @@ func (r *GroupMembershipReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder.Watches(
 		&iammiloapiscomv1alpha1.User{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueueGroupMembershipsForUserChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	controllerBuilder.Watches(
 		&iammiloapiscomv1alpha1.Group{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueueGroupMembershipsForGroupChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	return controllerBuilder.Complete(r)

--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -22,11 +22,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -810,12 +812,14 @@ func (r *PolicyBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder.Watches(
 		&iamdatumapiscomv1alpha1.ProtectedResource{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueuePolicyBindingsForProtectedResourceChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	// Watch for changes to Role CRs and enqueue PolicyBindings that might be affected.
 	controllerBuilder.Watches(
 		&iamdatumapiscomv1alpha1.Role{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueuePolicyBindingsForRoleChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	return controllerBuilder.WithOptions(controller.Options{

--- a/internal/controller/policybinding_controller.go
+++ b/internal/controller/policybinding_controller.go
@@ -191,6 +191,7 @@ func (r *PolicyBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.updatePolicyBindingStatus(ctx, policyBinding, oldStatus, currentGeneration); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update PolicyBinding status after successful validations before OpenFGA reconciliation: %w", err)
 	}
+	oldStatus = policyBinding.Status.DeepCopy()
 
 	// Reconcile with OpenFGA. This creates/updates/deletes tuples in OpenFGA based on the PolicyBinding. This step also
 	// implicitly validates the RoleRef by attempting to use the role.

--- a/internal/controller/role_controller.go
+++ b/internal/controller/role_controller.go
@@ -16,10 +16,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -595,6 +597,7 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder.Watches(
 		&iamdatumapiscomv1alpha1.ProtectedResource{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForProtectedResourceChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	// Watch Roles so that when a previously-missing inherited Role appears, the
@@ -603,6 +606,7 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder.Watches(
 		&iamdatumapiscomv1alpha1.Role{},
 		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForInheritedRoleChange),
+		builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 	)
 
 	return controllerBuilder.Complete(r)


### PR DESCRIPTION
### Summary
Resolves PolicyBinding reconciliation delays, status conflict errors, and redundant queue enqueuing loops in the OpenFGA provider.
### Changes
* **Centralized Timeout & Keepalives**: Added a gRPC client interceptor for client-side timeouts and enabled gRPC keepalives to prevent hung connection starvation.
* **Configurable Flags**: Added `--openfga-timeout`, `--openfga-keepalive-time`, and `--openfga-keepalive-timeout` command-line flags.
* **Status Conflict Fix**: Updated the cached `oldStatus` after the first update in `PolicyBindingReconciler` to avoid `object has been modified` conflict loops.
* **Watch Optimizations**: Configured `GenerationChangedPredicate` on secondary resource watches (`Role`, `ProtectedResource`, `User`, `Group`) to prevent queue flooding from metadata/status changes.