### PR TITLE
Increase PolicyBinding reconcile concurrency

### DIFF
--- a/config/base/services/controller-manager/manager.yaml
+++ b/config/base/services/controller-manager/manager.yaml
@@ -46,7 +46,7 @@ spec:
           - --configmap-namespace=$(CONFIGMAP_NAMESPACE)
           - --server-config=$(OPENFGA_CONTROLLER_MANAGER_CONFIG_PATH)
           - --core-control-plane-kubeconfig=$(CORE_CONTROL_PLANE_KUBECONFIG_PATH)
-          - --policybinding-max-concurrent-reconciles=8
+          - --policybinding-max-concurrent-reconciles=20
           - --openfga-timeout=$(OPENFGA_TIMEOUT)
           - --openfga-keepalive-time=$(OPENFGA_KEEPALIVE_TIME)
           - --openfga-keepalive-timeout=$(OPENFGA_KEEPALIVE_TIMEOUT)
@@ -113,10 +113,10 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
+            cpu: 1000m
             memory: 128Mi
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 64Mi
         volumeMounts: []
       volumes: []


### PR DESCRIPTION
## Summary
Investigated a report of the OpenFGA gRPC connection being slow (5 min to reconcile a PolicyBinding) in staging. gRPC itself was healthy throughout — no transport errors, no non-OK codes, no pod restarts, OpenFGA check latency stayed at its normal ~20-25ms p99.

Now, every time the controller bootstraps, a burst of ~1200 PolicyBindings landed in the `policybinding` controller's workqueue at once (recurring e2e test churn and controller-bootstrap full-cache relists both produce this pattern), but only 8 workers (`--policybinding-max-concurrent-reconciles=8`) drain it. Each reconcile is a chain of sequential calls (fetch Role → validate subject → OpenFGA Read → OpenFGA Write → status update), so ~1200 items / 8 workers at a few seconds each stretched to minutes.
