### PR TITLE
fix: GroupMembership already exists reconcile error

### DIFF
--- a/internal/controller/systemgroup_controller.go
+++ b/internal/controller/systemgroup_controller.go
@@ -3,11 +3,10 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"go.miloapis.com/auth-provider-openfga/internal/openfga"
 	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
-	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -178,7 +177,7 @@ func (r *SystemGroupReconciler) writeSystemGroupTuple(ctx context.Context, obj c
 		},
 	})
 	if err != nil {
-		if isAlreadyExistsErr(err) {
+		if openfga.IsAlreadyExistsErr(err) {
 			log.V(1).Info("system group membership tuple already exists in OpenFGA", "name", obj.GetName())
 			return nil
 		}
@@ -209,7 +208,7 @@ func (r *SystemGroupReconciler) deleteSystemGroupTuple(ctx context.Context, obj 
 		},
 	})
 	if err != nil {
-		if isTupleNotFoundErr(err) {
+		if openfga.IsTupleNotFoundErr(err) {
 			log.V(1).Info("system group membership tuple already absent from OpenFGA", "name", obj.GetName())
 			return nil
 		}
@@ -234,27 +233,4 @@ func (r *SystemGroupReconciler) systemGroupTupleKey(obj client.Object) *openfgav
 		Relation: "member",
 		Object:   fmt.Sprintf("iam.miloapis.com/InternalUserGroup:%s", systemAuthenticatedGroup),
 	}
-}
-
-// isAlreadyExistsErr reports whether the gRPC error indicates that the tuple
-// already exists in OpenFGA (code 2017).
-func isAlreadyExistsErr(err error) bool {
-	if st, ok := status.FromError(err); ok {
-		// OpenFGA uses gRPC application error code 2017 for "already exists".
-		return st.Code() == 2017
-	}
-	// Fallback: check the error message for robustness across SDK versions.
-	return strings.Contains(err.Error(), "already exists")
-}
-
-// isTupleNotFoundErr reports whether the gRPC error indicates that the tuple
-// does not exist in OpenFGA. OpenFGA has been observed returning code 2017
-// ("cannot delete a tuple which does not exist") and code 2018; both are
-// treated as "not found" so deletion is idempotent.
-func isTupleNotFoundErr(err error) bool {
-	if st, ok := status.FromError(err); ok {
-		return st.Code() == 2017 || st.Code() == 2018
-	}
-	return strings.Contains(err.Error(), "cannot delete a tuple which does not exist") ||
-		strings.Contains(err.Error(), "not found")
 }

--- a/internal/openfga/errors.go
+++ b/internal/openfga/errors.go
@@ -1,0 +1,30 @@
+package openfga
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/status"
+)
+
+// IsAlreadyExistsErr reports whether the gRPC error indicates that the tuple
+// already exists in OpenFGA (code 2017).
+func IsAlreadyExistsErr(err error) bool {
+	if st, ok := status.FromError(err); ok {
+		// OpenFGA uses gRPC application error code 2017 for "already exists".
+		return st.Code() == 2017
+	}
+	// Fallback: check the error message for robustness across SDK versions.
+	return strings.Contains(err.Error(), "already exists")
+}
+
+// IsTupleNotFoundErr reports whether the gRPC error indicates that the tuple
+// does not exist in OpenFGA. OpenFGA has been observed returning code 2017
+// ("cannot delete a tuple which does not exist") and code 2018; both are
+// treated as "not found" so deletion is idempotent.
+func IsTupleNotFoundErr(err error) bool {
+	if st, ok := status.FromError(err); ok {
+		return st.Code() == 2017 || st.Code() == 2018
+	}
+	return strings.Contains(err.Error(), "cannot delete a tuple which does not exist") ||
+		strings.Contains(err.Error(), "not found")
+}

--- a/internal/openfga/errors_test.go
+++ b/internal/openfga/errors_test.go
@@ -1,0 +1,88 @@
+package openfga
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsAlreadyExistsErr(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "grpc status code 2017",
+			err:  status.Error(codes.Code(2017), "cannot write a tuple which already exists"),
+			want: true,
+		},
+		{
+			name: "grpc status other code",
+			err:  status.Error(codes.NotFound, "not found"),
+			want: false,
+		},
+		{
+			name: "non-status error with message fallback",
+			err:  errors.New("tuple already exists"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAlreadyExistsErr(tc.err); got != tc.want {
+				t.Errorf("IsAlreadyExistsErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsTupleNotFoundErr(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "grpc status code 2017",
+			err:  status.Error(codes.Code(2017), "the tuple to be deleted did not exist"),
+			want: true,
+		},
+		{
+			name: "grpc status code 2018",
+			err:  status.Error(codes.Code(2018), "cannot delete a tuple which does not exist"),
+			want: true,
+		},
+		{
+			name: "grpc status other code",
+			err:  status.Error(codes.Internal, "boom"),
+			want: false,
+		},
+		{
+			name: "non-status error with message fallback",
+			err:  errors.New("cannot delete a tuple which does not exist"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTupleNotFoundErr(tc.err); got != tc.want {
+				t.Errorf("IsTupleNotFoundErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/openfga/group_member_reconciler.go
+++ b/internal/openfga/group_member_reconciler.go
@@ -34,7 +34,7 @@ func (r *UserGroupReconciler) AddMemberToGroup(ctx context.Context, joinToGroupR
 
 	checkResp, err := r.checkIfTupleKeyExists(ctx, tupleKeys[0])
 	if err != nil {
-		return fmt.Errorf("f ailed to check if GroupMember tuple key exists: %w", err)
+		return fmt.Errorf("failed to check if GroupMember tuple key exists: %w", err)
 	}
 
 	// If the tuple key does not exist, write it to the OpenFGA store
@@ -47,6 +47,10 @@ func (r *UserGroupReconciler) AddMemberToGroup(ctx context.Context, joinToGroupR
 		}
 		_, err = r.Client.Write(ctx, writeRequest)
 		if err != nil {
+			// Check above can be racy; already-exists means the tuple is there, so treat as success.
+			if IsAlreadyExistsErr(err) {
+				return nil
+			}
 			return fmt.Errorf("failed to write group membership tuple: %w", err)
 		}
 	}
@@ -81,7 +85,11 @@ func (r *UserGroupReconciler) RemoveMemberFromGroup(ctx context.Context, groupMe
 			Deletes: deleteRequest,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to delete group membership : %w", err)
+			// Check above can be racy; not-found means the tuple is gone, so treat as success.
+			if IsTupleNotFoundErr(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to delete group membership: %w", err)
 		}
 	}
 

--- a/internal/openfga/group_member_reconciler_test.go
+++ b/internal/openfga/group_member_reconciler_test.go
@@ -1,0 +1,171 @@
+package openfga
+
+import (
+	"context"
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// groupMemberMockClient is a mock implementation of openfgav1.OpenFGAServiceClient
+// for testing UserGroupReconciler's Check/Write interactions.
+type groupMemberMockClient struct {
+	openfgav1.OpenFGAServiceClient
+	CheckFunc func(ctx context.Context, in *openfgav1.CheckRequest, opts ...grpc.CallOption) (*openfgav1.CheckResponse, error)
+	WriteFunc func(ctx context.Context, in *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error)
+}
+
+func (m *groupMemberMockClient) Check(ctx context.Context, in *openfgav1.CheckRequest, opts ...grpc.CallOption) (*openfgav1.CheckResponse, error) {
+	return m.CheckFunc(ctx, in, opts...)
+}
+
+func (m *groupMemberMockClient) Write(ctx context.Context, in *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+	return m.WriteFunc(ctx, in, opts...)
+}
+
+func TestUserGroupReconciler_AddMemberToGroup(t *testing.T) {
+	logf.SetLogger(zap.New())
+
+	req := GroupMembershipRequest{GroupUID: types.UID("group-uid"), MemberUID: types.UID("member-uid")}
+
+	testCases := []struct {
+		name          string
+		checkResp     *openfgav1.CheckResponse
+		checkErr      error
+		writeErr      error
+		wantErr       bool
+		wantWriteCall bool
+	}{
+		{
+			name:          "tuple already allowed, no write needed",
+			checkResp:     &openfgav1.CheckResponse{Allowed: true},
+			wantWriteCall: false,
+		},
+		{
+			name:          "tuple missing, write succeeds",
+			checkResp:     &openfgav1.CheckResponse{Allowed: false},
+			wantWriteCall: true,
+		},
+		{
+			name:          "tuple missing, write races and already exists is treated as success",
+			checkResp:     &openfgav1.CheckResponse{Allowed: false},
+			writeErr:      status.Error(codes.Code(2017), "cannot write a tuple which already exists"),
+			wantWriteCall: true,
+			wantErr:       false,
+		},
+		{
+			name:          "tuple missing, write fails with unrelated error",
+			checkResp:     &openfgav1.CheckResponse{Allowed: false},
+			writeErr:      status.Error(codes.Internal, "boom"),
+			wantWriteCall: true,
+			wantErr:       true,
+		},
+		{
+			name:     "check fails",
+			checkErr: status.Error(codes.Internal, "boom"),
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeCalled := false
+			client := &groupMemberMockClient{
+				CheckFunc: func(ctx context.Context, in *openfgav1.CheckRequest, opts ...grpc.CallOption) (*openfgav1.CheckResponse, error) {
+					return tc.checkResp, tc.checkErr
+				},
+				WriteFunc: func(ctx context.Context, in *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+					writeCalled = true
+					if tc.writeErr != nil {
+						return nil, tc.writeErr
+					}
+					return &openfgav1.WriteResponse{}, nil
+				},
+			}
+
+			r := &UserGroupReconciler{StoreID: "store-1", Client: client}
+			err := r.AddMemberToGroup(context.Background(), req)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("AddMemberToGroup() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if writeCalled != tc.wantWriteCall {
+				t.Fatalf("Write called = %v, want %v", writeCalled, tc.wantWriteCall)
+			}
+		})
+	}
+}
+
+func TestUserGroupReconciler_RemoveMemberFromGroup(t *testing.T) {
+	logf.SetLogger(zap.New())
+
+	req := GroupMembershipRequest{GroupUID: types.UID("group-uid"), MemberUID: types.UID("member-uid")}
+
+	testCases := []struct {
+		name          string
+		checkResp     *openfgav1.CheckResponse
+		checkErr      error
+		writeErr      error
+		wantErr       bool
+		wantWriteCall bool
+	}{
+		{
+			name:          "tuple already absent, no delete needed",
+			checkResp:     &openfgav1.CheckResponse{Allowed: false},
+			wantWriteCall: false,
+		},
+		{
+			name:          "tuple present, delete succeeds",
+			checkResp:     &openfgav1.CheckResponse{Allowed: true},
+			wantWriteCall: true,
+		},
+		{
+			name:          "tuple present, delete races and not-found is treated as success",
+			checkResp:     &openfgav1.CheckResponse{Allowed: true},
+			writeErr:      status.Error(codes.Code(2017), "the tuple to be deleted did not exist"),
+			wantWriteCall: true,
+			wantErr:       false,
+		},
+		{
+			name:          "tuple present, delete fails with unrelated error",
+			checkResp:     &openfgav1.CheckResponse{Allowed: true},
+			writeErr:      status.Error(codes.Internal, "boom"),
+			wantWriteCall: true,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeCalled := false
+			client := &groupMemberMockClient{
+				CheckFunc: func(ctx context.Context, in *openfgav1.CheckRequest, opts ...grpc.CallOption) (*openfgav1.CheckResponse, error) {
+					return tc.checkResp, tc.checkErr
+				},
+				WriteFunc: func(ctx context.Context, in *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error) {
+					writeCalled = true
+					if tc.writeErr != nil {
+						return nil, tc.writeErr
+					}
+					return &openfgav1.WriteResponse{}, nil
+				},
+			}
+
+			r := &UserGroupReconciler{StoreID: "store-1", Client: client}
+			err := r.RemoveMemberFromGroup(context.Background(), req)
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("RemoveMemberFromGroup() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if writeCalled != tc.wantWriteCall {
+				t.Fatalf("Write called = %v, want %v", writeCalled, tc.wantWriteCall)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `groupmembership` controller treats OpenFGA's "tuple already exists" error as a real failure. When that happens, the controller retries forever and never succeeds, since the tuple is already there. One stuck object retrying in a tight loop was enough to push this controller's error rate over the `ControllerReconcileErrorRatioCritical` alert threshold, even though everything else was reconciling fine.

The code already checks whether a tuple exists before writing it, but that check can be stale by the time the write happens. So the check says "not there yet," the write happens anyway, and it fails with "already exists." Today that failure is treated as a hard error.

`systemgroup` controller already handles this same OpenFGA error correctly. This PR applies the same fix to `groupmembership`.

#### Fix

- Moved the existing error-checking helpers (isAlreadyExistsErr, isTupleNotFoundErr) into a shared package
- `AddMemberToGroup`: if Write fails because the tuple already exists, treat it as success.
- `RemoveMemberFromGroup`: if the delete fails because the tuple is already gone, treat it as success.

This is safe because an OpenFGA tuple is fully identified by (user, relation, object) — there's no other data attached to it that could be different. The tuple we tried to write is built fresh from the `GroupMembership`'s current spec every time, so "already exists" can only mean the exact tuple we wanted is already there.